### PR TITLE
feat(web): implement SEP-10 Freighter WebAuth with JWT

### DIFF
--- a/web/app/invoices/[id]/page.tsx
+++ b/web/app/invoices/[id]/page.tsx
@@ -3,9 +3,9 @@
 
 import { useParams, useRouter } from 'next/navigation';
 import { useState, useCallback } from 'react';
-import axios from 'axios';
 import { generatePaymentUri, openPaymentWallet, getWalletInfo } from '@/lib/sep0007';
 import { usePollInvoiceStatus } from '@/hooks/use-poll-invoice-status';
+import { apiClient } from '@/lib/api-client';
 
 interface Invoice {
   id: string;
@@ -31,8 +31,6 @@ interface WalletInfo {
   message: string;
 }
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
-
 export default function InvoiceDetailPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
@@ -44,7 +42,7 @@ export default function InvoiceDetailPage() {
 
   // Fetch invoice function for polling
   const fetchInvoice = useCallback(async (id: string) => {
-    const response = await axios.get<Invoice>(`${API_URL}/invoices/${id}`);
+    const response = await apiClient.get<Invoice>(`/invoices/${id}`);
     return response.data;
   }, []);
 

--- a/web/app/invoices/page.tsx
+++ b/web/app/invoices/page.tsx
@@ -2,8 +2,9 @@
 'use client';
 
 import Link from 'next/link';
-import axios from 'axios';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { WalletAuthControls } from '@/components/wallet-auth-controls';
 
 interface Invoice {
   id: string;
@@ -25,15 +26,12 @@ interface InvoicesPage {
   hasMore: boolean;
 }
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
-
 async function fetchInvoicesPage(page: number, pageSize: number): Promise<InvoicesPage> {
   const params = new URLSearchParams({
     page: String(page),
     limit: String(pageSize),
   }).toString();
-  const url = `${API_URL}/invoices?${params}`;
-  const response = await axios.get(url);
+  const response = await apiClient.get(`/invoices?${params}`);
   const data: unknown = response.data;
 
   if (Array.isArray(data)) {
@@ -109,6 +107,10 @@ export default function InvoicesPage() {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">Invoices</h1>
           <p className="mt-2 text-gray-600">View and manage your invoices</p>
+        </div>
+
+        <div className="mb-6">
+          <WalletAuthControls />
         </div>
 
         {/* Error State */}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,8 +1,37 @@
 
-const Login = () => {
-  return (
-    <div>Login</div>
-  )
-}
+'use client';
 
-export default Login
+import Link from 'next/link';
+import { WalletAuthControls } from '@/components/wallet-auth-controls';
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-2xl">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900">Wallet Sign-In</h1>
+          <p className="mt-2 text-gray-600">
+            Connect Freighter, sign your challenge, and get a JWT for protected API calls.
+          </p>
+        </div>
+
+        <WalletAuthControls />
+
+        <div className="mt-6 rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-700 shadow-sm">
+          <p className="font-medium text-gray-900">How it works</p>
+          <ol className="mt-2 list-decimal space-y-1 pl-4">
+            <li>Connect your Freighter wallet.</li>
+            <li>Sign the backend challenge.</li>
+            <li>Receive a JWT and access protected routes.</li>
+          </ol>
+        </div>
+
+        <div className="mt-6">
+          <Link href="/invoices" className="text-sm font-medium text-blue-600 hover:text-blue-700">
+            Go to invoices
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/providers.tsx
+++ b/web/app/providers.tsx
@@ -3,13 +3,14 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode, useState } from 'react';
+import { WalletAuthProvider } from '@/hooks/use-wallet-auth';
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
     <QueryClientProvider client={queryClient}>
-      {children}
+      <WalletAuthProvider>{children}</WalletAuthProvider>
     </QueryClientProvider>
   );
 }

--- a/web/components/wallet-auth-controls.tsx
+++ b/web/components/wallet-auth-controls.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useWalletAuth } from '@/hooks/use-wallet-auth';
+
+function getChipClasses(status: 'disconnected' | 'connected' | 'signed-in'): string {
+  if (status === 'signed-in') {
+    return 'bg-green-100 text-green-800 border-green-200';
+  }
+
+  if (status === 'connected') {
+    return 'bg-blue-100 text-blue-800 border-blue-200';
+  }
+
+  return 'bg-gray-100 text-gray-700 border-gray-200';
+}
+
+function getStatusLabel(status: 'disconnected' | 'connected' | 'signed-in'): string {
+  if (status === 'signed-in') {
+    return 'Signed In';
+  }
+
+  if (status === 'connected') {
+    return 'Connected';
+  }
+
+  return 'Disconnected';
+}
+
+export function WalletAuthControls() {
+  const {
+    status,
+    publicKey,
+    isFreighterReady,
+    isLoading,
+    message,
+    error,
+    connectWallet,
+    signIn,
+    signOut,
+    clearMessage,
+  } = useWalletAuth();
+
+  useEffect(() => {
+    if (!message && !error) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      clearMessage();
+    }, 5000);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [message, error, clearMessage]);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+            Wallet Status
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <span
+              className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${getChipClasses(status)}`}
+            >
+              {getStatusLabel(status)}
+            </span>
+            {publicKey && (
+              <span className="text-xs text-gray-500">
+                {publicKey.slice(0, 6)}...{publicKey.slice(-4)}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {status === 'disconnected' && (
+            <button
+              onClick={() => {
+                void connectWallet().catch(() => undefined);
+              }}
+              disabled={isLoading}
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+            >
+              {isLoading ? 'Connecting...' : 'Connect Wallet'}
+            </button>
+          )}
+
+          {status === 'connected' && (
+            <button
+              onClick={() => {
+                void signIn().catch(() => undefined);
+              }}
+              disabled={isLoading}
+              className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+            >
+              {isLoading ? 'Signing...' : 'Sign Challenge'}
+            </button>
+          )}
+
+          {status === 'signed-in' && (
+            <button
+              onClick={signOut}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Sign Out
+            </button>
+          )}
+        </div>
+      </div>
+
+      {!isFreighterReady && (
+        <p className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-2 text-sm text-amber-900">
+          Freighter extension not detected. Install Freighter to connect your Stellar wallet.
+        </p>
+      )}
+
+      {message && (
+        <p className="mt-3 rounded-md border border-green-200 bg-green-50 p-2 text-sm text-green-900">
+          {message}
+        </p>
+      )}
+
+      {error && (
+        <p className="mt-3 rounded-md border border-red-200 bg-red-50 p-2 text-sm text-red-900">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/hooks/use-wallet-auth.tsx
+++ b/web/hooks/use-wallet-auth.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { AuthService } from '@/lib/auth-service';
+import {
+  isFreighterInstalled,
+  requestFreighterPublicKey,
+  signChallengeWithFreighter,
+} from '@/lib/freighter-auth';
+import { setApiAccessToken } from '@/lib/api-client';
+
+type WalletStatus = 'disconnected' | 'connected' | 'signed-in';
+
+type StoredAuth = {
+  accessToken: string | null;
+  publicKey: string | null;
+};
+
+const AUTH_STORAGE_KEY = 'invoisio:web:wallet-auth';
+
+interface WalletAuthContextValue {
+  status: WalletStatus;
+  publicKey: string | null;
+  isFreighterReady: boolean;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  message: string | null;
+  error: string | null;
+  connectWallet: () => Promise<void>;
+  signIn: () => Promise<void>;
+  signOut: () => void;
+  clearMessage: () => void;
+}
+
+const WalletAuthContext = createContext<WalletAuthContextValue | null>(null);
+
+function readStoredAuth(): StoredAuth {
+  if (typeof window === 'undefined') {
+    return { accessToken: null, publicKey: null };
+  }
+
+  const raw = window.localStorage.getItem(AUTH_STORAGE_KEY);
+  if (raw == null || raw.length === 0) {
+    return { accessToken: null, publicKey: null };
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredAuth>;
+    return {
+      accessToken: typeof parsed.accessToken === 'string' ? parsed.accessToken : null,
+      publicKey: typeof parsed.publicKey === 'string' ? parsed.publicKey : null,
+    };
+  } catch {
+    return { accessToken: null, publicKey: null };
+  }
+}
+
+function persistAuth(next: StoredAuth): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(next));
+}
+
+function clearStoredAuth(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.removeItem(AUTH_STORAGE_KEY);
+}
+
+function normalizeAuthError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (/not installed/i.test(message)) {
+    return 'Freighter wallet is not installed. Install the extension to continue.';
+  }
+
+  if (/reject|denied|declin/i.test(message)) {
+    return 'Signature request was rejected. Please approve it in Freighter to sign in.';
+  }
+
+  if (/invalid signature/i.test(message)) {
+    return 'The signature could not be verified. Please try again.';
+  }
+
+  if (/nonce|challenge/i.test(message)) {
+    return 'Could not get a valid sign-in challenge. Please retry.';
+  }
+
+  return message || 'Authentication failed. Please try again.';
+}
+
+export function WalletAuthProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<WalletStatus>('disconnected');
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [isFreighterReady, setIsFreighterReady] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const freighterReady = isFreighterInstalled();
+    setIsFreighterReady(freighterReady);
+
+    const stored = readStoredAuth();
+    if (stored.accessToken) {
+      setApiAccessToken(stored.accessToken);
+      setPublicKey(stored.publicKey);
+      setStatus('signed-in');
+    } else if (stored.publicKey) {
+      setPublicKey(stored.publicKey);
+      setStatus('connected');
+    } else {
+      setStatus('disconnected');
+    }
+
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    const validateExistingToken = async () => {
+      const stored = readStoredAuth();
+      if (!stored.accessToken) {
+        return;
+      }
+
+      try {
+        setApiAccessToken(stored.accessToken);
+        await AuthService.getMe();
+      } catch {
+        setApiAccessToken(null);
+        clearStoredAuth();
+        setPublicKey(null);
+        setStatus('disconnected');
+      }
+    };
+
+    void validateExistingToken();
+  }, []);
+
+  const connectWallet = useCallback(async () => {
+    setError(null);
+    setMessage(null);
+
+    if (!isFreighterInstalled()) {
+      setIsFreighterReady(false);
+      const msg = 'Freighter wallet is not installed.';
+      setError(msg);
+      throw new Error(msg);
+    }
+
+    setIsLoading(true);
+
+    try {
+      const key = await requestFreighterPublicKey();
+      setPublicKey(key);
+      setStatus('connected');
+      persistAuth({ accessToken: null, publicKey: key });
+      setMessage(`Wallet connected: ${key.slice(0, 6)}...${key.slice(-4)}`);
+    } catch (err) {
+      const normalized = normalizeAuthError(err);
+      setError(normalized);
+      throw new Error(normalized);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const signIn = useCallback(async () => {
+    setError(null);
+    setMessage(null);
+    setIsLoading(true);
+
+    try {
+      let key = publicKey;
+      if (!key) {
+        key = await requestFreighterPublicKey();
+        setPublicKey(key);
+        setStatus('connected');
+      }
+
+      const { nonce } = await AuthService.requestChallenge(key);
+      const signedNonce = await signChallengeWithFreighter(nonce);
+      const { accessToken } = await AuthService.verifySignature(key, signedNonce);
+
+      setApiAccessToken(accessToken);
+      persistAuth({ accessToken, publicKey: key });
+      setPublicKey(key);
+      setStatus('signed-in');
+
+      // Confirm protected API access immediately after token issuance.
+      await AuthService.getMe();
+
+      setMessage('Signed in successfully. Protected API access is active.');
+    } catch (err) {
+      const normalized = normalizeAuthError(err);
+      setError(normalized);
+      throw new Error(normalized);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [publicKey]);
+
+  const signOut = useCallback(() => {
+    setApiAccessToken(null);
+    clearStoredAuth();
+    setPublicKey(null);
+    setStatus('disconnected');
+    setError(null);
+    setMessage('Signed out successfully.');
+  }, []);
+
+  const clearMessage = useCallback(() => {
+    setError(null);
+    setMessage(null);
+  }, []);
+
+  const value = useMemo<WalletAuthContextValue>(
+    () => ({
+      status,
+      publicKey,
+      isFreighterReady,
+      isLoading,
+      isAuthenticated: status === 'signed-in',
+      message,
+      error,
+      connectWallet,
+      signIn,
+      signOut,
+      clearMessage,
+    }),
+    [
+      status,
+      publicKey,
+      isFreighterReady,
+      isLoading,
+      message,
+      error,
+      connectWallet,
+      signIn,
+      signOut,
+      clearMessage,
+    ],
+  );
+
+  return (
+    <WalletAuthContext.Provider value={value}>{children}</WalletAuthContext.Provider>
+  );
+}
+
+export function useWalletAuth(): WalletAuthContextValue {
+  const context = useContext(WalletAuthContext);
+  if (context == null) {
+    throw new Error('useWalletAuth must be used within WalletAuthProvider');
+  }
+  return context;
+}

--- a/web/lib/api-client.ts
+++ b/web/lib/api-client.ts
@@ -1,0 +1,46 @@
+import axios, { AxiosError } from 'axios';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
+
+let accessToken: string | null = null;
+
+export const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+apiClient.interceptors.request.use((config) => {
+  if (accessToken != null && accessToken.length > 0) {
+    config.headers = config.headers ?? {};
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return config;
+});
+
+export function setApiAccessToken(token: string | null): void {
+  accessToken = token;
+}
+
+export function extractApiErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const err = error as AxiosError<{ message?: string | string[] }>;
+    const message = err.response?.data?.message;
+
+    if (Array.isArray(message)) {
+      return message.join(', ');
+    }
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+
+    if (typeof err.message === 'string' && err.message.length > 0) {
+      return err.message;
+    }
+  }
+
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+
+  return 'Something went wrong. Please try again.';
+}

--- a/web/lib/auth-service.ts
+++ b/web/lib/auth-service.ts
@@ -1,0 +1,53 @@
+import { apiClient, extractApiErrorMessage } from '@/lib/api-client';
+
+export interface NonceResponse {
+  nonce: string;
+  expiresAt: number;
+}
+
+export interface VerifyResponse {
+  accessToken: string;
+}
+
+export interface MeResponse {
+  id: string;
+  publicKey: string;
+  createdAt: string;
+}
+
+export const AuthService = {
+  async requestChallenge(publicKey: string): Promise<NonceResponse> {
+    try {
+      const response = await apiClient.post<NonceResponse>('/auth/nonce', {
+        publicKey,
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(extractApiErrorMessage(error));
+    }
+  },
+
+  async verifySignature(
+    publicKey: string,
+    signedNonce: string,
+  ): Promise<VerifyResponse> {
+    try {
+      const response = await apiClient.post<VerifyResponse>('/auth/verify', {
+        publicKey,
+        signedNonce,
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(extractApiErrorMessage(error));
+    }
+  },
+
+  async getMe(): Promise<MeResponse> {
+    try {
+      const response = await apiClient.get<MeResponse>('/auth/me');
+      return response.data;
+    } catch (error) {
+      throw new Error(extractApiErrorMessage(error));
+    }
+  },
+};

--- a/web/lib/freighter-auth.ts
+++ b/web/lib/freighter-auth.ts
@@ -1,0 +1,150 @@
+type FreighterLike = {
+  requestAccess?: () => Promise<unknown>;
+  getPublicKey?: () => Promise<unknown>;
+  signMessage?: (message: string, opts?: unknown) => Promise<unknown>;
+};
+
+declare global {
+  interface Window {
+    freighterApi?: FreighterLike;
+    freighter?: FreighterLike;
+  }
+}
+
+function getFreighterApi(): FreighterLike | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.freighterApi ?? window.freighter ?? null;
+}
+
+function looksLikePublicKey(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith('G') && value.length === 56;
+}
+
+function toBase64(value: Uint8Array): string {
+  let raw = '';
+  for (let i = 0; i < value.length; i += 1) {
+    raw += String.fromCharCode(value[i]);
+  }
+
+  return btoa(raw);
+}
+
+function extractSignature(result: unknown): string | null {
+  if (typeof result === 'string' && result.length > 0) {
+    return result;
+  }
+
+  if (result != null && typeof result === 'object') {
+    const data = result as {
+      signature?: unknown;
+      signedMessage?: unknown;
+      signed_message?: unknown;
+    };
+
+    if (typeof data.signature === 'string' && data.signature.length > 0) {
+      return data.signature;
+    }
+
+    if (data.signature instanceof Uint8Array) {
+      return toBase64(data.signature);
+    }
+
+    if (
+      typeof data.signedMessage === 'string' &&
+      data.signedMessage.length > 0
+    ) {
+      return data.signedMessage;
+    }
+
+    if (
+      typeof data.signed_message === 'string' &&
+      data.signed_message.length > 0
+    ) {
+      return data.signed_message;
+    }
+  }
+
+  return null;
+}
+
+export function isFreighterInstalled(): boolean {
+  const api = getFreighterApi();
+  return api != null;
+}
+
+export async function requestFreighterPublicKey(): Promise<string> {
+  const api = getFreighterApi();
+
+  if (!api) {
+    throw new Error('Freighter is not installed.');
+  }
+
+  if (typeof api.requestAccess === 'function') {
+    const accessResult = await api.requestAccess();
+    if (looksLikePublicKey(accessResult)) {
+      return accessResult;
+    }
+  }
+
+  if (typeof api.getPublicKey === 'function') {
+    const keyResult = await api.getPublicKey();
+
+    if (looksLikePublicKey(keyResult)) {
+      return keyResult;
+    }
+
+    if (keyResult != null && typeof keyResult === 'object') {
+      const data = keyResult as { publicKey?: unknown; address?: unknown };
+      if (looksLikePublicKey(data.publicKey)) {
+        return data.publicKey;
+      }
+      if (looksLikePublicKey(data.address)) {
+        return data.address;
+      }
+    }
+  }
+
+  throw new Error('Unable to read public key from Freighter.');
+}
+
+export async function signChallengeWithFreighter(
+  challenge: string,
+): Promise<string> {
+  const api = getFreighterApi();
+
+  if (!api || typeof api.signMessage !== 'function') {
+    throw new Error('Freighter does not support message signing in this browser.');
+  }
+
+  try {
+    const result = await api.signMessage(challenge);
+    const signature = extractSignature(result);
+
+    if (!signature) {
+      throw new Error('Could not extract a signature from Freighter response.');
+    }
+
+    return signature;
+  } catch (error) {
+    if (
+      error != null &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code: unknown }).code === 4001
+    ) {
+      throw new Error('Signature request was rejected by user.');
+    }
+
+    if (
+      error instanceof Error &&
+      /(reject|denied|declin)/i.test(error.message)
+    ) {
+      throw new Error('Signature request was rejected by user.');
+    }
+
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary #85 

Implements SEP-10 WebAuth with Freighter for the `web` app, including connect, challenge-sign, verify, JWT persistence, and sign-out.

Closes #85.

## What Changed

- Added Freighter wallet auth flow:
- `Connect Wallet` action
- challenge request (`POST /auth/nonce`)
- challenge signing via Freighter
- signature verification (`POST /auth/verify`)
- JWT handling for protected APIs
- sign-out flow that clears auth state

- Added auth state + persistence:
- new `WalletAuthProvider` and `useWalletAuth` hook
- persisted state in `localStorage`
- status model: `Disconnected` -> `Connected` -> `Signed In`
- startup token validation via protected `GET /auth/me`

- Added UI components/pages integration:
- new reusable `WalletAuthControls` component (button + status chip + messages)
- integrated into `web/app/login/page.tsx`
- integrated into `web/app/invoices/page.tsx`

- Added shared API/auth utilities:
- token-aware axios client with Bearer injection
- centralized auth service for challenge/verify/me endpoints
- Freighter adapter with robust response parsing and user-rejection handling

- Updated invoice API calls to use shared client:
- `web/app/invoices/page.tsx`
- `web/app/invoices/[id]/page.tsx`

## Files

- `web/app/providers.tsx`
- `web/app/login/page.tsx`
- `web/app/invoices/page.tsx`
- `web/app/invoices/[id]/page.tsx`
- `web/components/wallet-auth-controls.tsx` (new)
- `web/hooks/use-wallet-auth.tsx` (new)
- `web/lib/api-client.ts` (new)
- `web/lib/auth-service.ts` (new)
- `web/lib/freighter-auth.ts` (new)

## Acceptance Criteria Mapping

- Happy path works:
- connect wallet
- sign challenge
- receive JWT
- protected endpoint check (`/auth/me`) succeeds

- Error handling:
- wallet missing
- user rejects signature
- invalid/failed signature verification
- user-friendly inline messages

- Auth persistence across navigation:
- restored from storage via provider on app load

- Sign-out:
- token + wallet state cleared
- UI returns to unauthenticated status

## Validation

- `npm install` (in `web`) completed successfully
- `npm run lint` (in `web`) passed

Closes #85 