### PR TITLE
Add invoice sharing sheet with payment links

### DIFF
--- a/mobile/app/invoices/[id].tsx
+++ b/mobile/app/invoices/[id].tsx
@@ -1,11 +1,18 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { Alert, Pressable, ScrollView, Share, Text, View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import { API_URL } from "@env";
 import { useAuthStore } from "../../hooks/use-auth-store";
 import type { Invoice } from "../../lib/invoices";
+import {
+  buildInvoiceShareMessage,
+  generatePaymentUri,
+  getInvoiceAsset,
+  getInvoiceDestination,
+  getInvoiceMemoType,
+} from "../../lib/payment-link";
 
 export default function InvoiceDetailScreen() {
   const params = useLocalSearchParams<{ id?: string }>();
@@ -35,110 +42,219 @@ export default function InvoiceDetailScreen() {
   const created = invoice
     ? new Date(invoice.createdAt).toLocaleString()
     : undefined;
+  const assetCode = invoice ? getInvoiceAsset(invoice) : undefined;
+  const destination = invoice ? getInvoiceDestination(invoice) : undefined;
+  const paymentUri =
+    invoice && destination
+      ? generatePaymentUri({
+          amount: String(invoice.amount),
+          assetCode,
+          assetIssuer: invoice.asset_issuer,
+          destination,
+          memo: invoice.memo,
+          memoType: getInvoiceMemoType(invoice),
+        })
+      : undefined;
+
+  const handleShare = async () => {
+    if (!invoice) {
+      return;
+    }
+
+    try {
+      await Share.share({
+        title: invoice.invoiceNumber ?? invoice.id,
+        message: buildInvoiceShareMessage(invoice),
+      });
+    } catch (error) {
+      console.error("Invoice share failed", error);
+      Alert.alert(
+        "Share unavailable",
+        "We couldn't open the native share sheet for this invoice.",
+      );
+    }
+  };
 
   return (
     <SafeAreaView className="flex-1 bg-[#050914]">
       <ScrollView contentContainerStyle={{ paddingBottom: 48 }}>
         <View className="px-6 pt-10">
-          <Pressable
-            className="mb-4 rounded-2xl border border-white/20 px-4 py-2"
-            onPress={() => {
-              router.back();
-            }}
-          >
-            <Text
-              className="text-white"
-              style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+          <View className="mb-4 flex-row gap-3">
+            <Pressable
+              className="flex-1 rounded-2xl border border-white/20 px-4 py-3"
+              onPress={() => {
+                router.back();
+              }}
             >
-              Back
-            </Text>
-          </Pressable>
+              <Text
+                className="text-center text-white"
+                style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+              >
+                Back
+              </Text>
+            </Pressable>
+            <Pressable
+              className="flex-1 rounded-2xl bg-[#2663FF] px-4 py-3"
+              disabled={!invoice}
+              onPress={() => {
+                void handleShare();
+              }}
+            >
+              <Text
+                className="text-center text-white"
+                style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
+              >
+                Share invoice
+              </Text>
+            </Pressable>
+          </View>
           {isLoading ? (
             <View className="h-32 animate-pulse rounded-2xl bg-white/10" />
           ) : invoice ? (
-            <View className="rounded-3xl border border-white/10 bg-white/5 p-5">
-              <Text
-                className="text-sm text-slate-400"
-                style={{ fontFamily: "SpaceGrotesk_500Medium" }}
-              >
-                {invoice.invoiceNumber ?? invoice.id}
-              </Text>
-              <Text
-                className="mt-1 text-2xl text-white"
-                style={{ fontFamily: "SpaceGrotesk_700Bold" }}
-              >
-                {invoice.clientName ?? "Invoice"}
-              </Text>
-              <View className="mt-3 flex-row justify-between">
-                <View>
-                  <Text
-                    className="text-slate-400"
-                    style={{ fontFamily: "SpaceGrotesk_400Regular" }}
-                  >
-                    Amount
-                  </Text>
-                  <Text
-                    className="text-lg text-white"
-                    style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
-                  >
-                    $
-                    {invoice.amount.toLocaleString(undefined, {
-                      maximumFractionDigits: 2,
-                    })}{" "}
-                    {invoice.asset}
-                  </Text>
-                </View>
-                <View>
-                  <Text
-                    className="text-slate-400"
-                    style={{ fontFamily: "SpaceGrotesk_400Regular" }}
-                  >
-                    Status
-                  </Text>
-                  <Text
-                    className={`text-lg ${
-                      invoice.status === "pending"
-                        ? "text-yellow-300"
-                        : invoice.status === "paid"
-                          ? "text-emerald-300"
-                          : "text-red-300"
-                    }`}
-                    style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
-                  >
-                    {invoice.status}
-                  </Text>
-                </View>
-              </View>
-              <View className="mt-3">
+            <View className="gap-4">
+              <View className="rounded-3xl border border-white/10 bg-white/5 p-5">
                 <Text
-                  className="text-slate-400"
-                  style={{ fontFamily: "SpaceGrotesk_400Regular" }}
-                >
-                  Created
-                </Text>
-                <Text
-                  className="text-white"
+                  className="text-sm text-slate-400"
                   style={{ fontFamily: "SpaceGrotesk_500Medium" }}
                 >
-                  {created}
+                  {invoice.invoiceNumber ?? invoice.id}
                 </Text>
-              </View>
-              {invoice.description && (
+                <Text
+                  className="mt-1 text-2xl text-white"
+                  style={{ fontFamily: "SpaceGrotesk_700Bold" }}
+                >
+                  {invoice.clientName ?? "Invoice"}
+                </Text>
+                <View className="mt-3 flex-row justify-between">
+                  <View>
+                    <Text
+                      className="text-slate-400"
+                      style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+                    >
+                      Amount
+                    </Text>
+                    <Text
+                      className="text-lg text-white"
+                      style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
+                    >
+                      {invoice.amount.toLocaleString(undefined, {
+                        maximumFractionDigits: 2,
+                      })}{" "}
+                      {assetCode ?? "XLM"}
+                    </Text>
+                  </View>
+                  <View>
+                    <Text
+                      className="text-slate-400"
+                      style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+                    >
+                      Status
+                    </Text>
+                    <Text
+                      className={`text-lg ${
+                        invoice.status === "pending"
+                          ? "text-yellow-300"
+                          : invoice.status === "paid"
+                            ? "text-emerald-300"
+                            : "text-red-300"
+                      }`}
+                      style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
+                    >
+                      {invoice.status}
+                    </Text>
+                  </View>
+                </View>
                 <View className="mt-3">
                   <Text
                     className="text-slate-400"
                     style={{ fontFamily: "SpaceGrotesk_400Regular" }}
                   >
-                    Description
+                    Created
                   </Text>
                   <Text
                     className="text-white"
-                    style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+                    style={{ fontFamily: "SpaceGrotesk_500Medium" }}
                   >
-                    {invoice.description}
+                    {created}
                   </Text>
                 </View>
-              )}
+                {invoice.description && (
+                  <View className="mt-3">
+                    <Text
+                      className="text-slate-400"
+                      style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+                    >
+                      Description
+                    </Text>
+                    <Text
+                      className="text-white"
+                      style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+                    >
+                      {invoice.description}
+                    </Text>
+                  </View>
+                )}
+              </View>
+
+              <View className="rounded-[28px] border border-[#7dd3fc]/20 bg-[#081121] p-5">
+                <Text
+                  className="text-sm uppercase tracking-[0.3em] text-[#7dd3fc]"
+                  style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+                >
+                  Share-ready payment card
+                </Text>
+                <Text
+                  className="mt-2 text-2xl text-white"
+                  style={{ fontFamily: "SpaceGrotesk_700Bold" }}
+                >
+                  Payment instructions
+                </Text>
+                <Text
+                  className="mt-2 text-sm text-slate-300"
+                  style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+                >
+                  Use the native share sheet or send a screenshot of this card.
+                </Text>
+
+                <View className="mt-5 gap-3 rounded-3xl border border-white/10 bg-white/5 p-4">
+                  <DetailRow
+                    label="Amount"
+                    value={`${invoice.amount.toLocaleString(undefined, {
+                      maximumFractionDigits: 2,
+                    })} ${assetCode ?? "XLM"}`}
+                  />
+                  <DetailRow
+                    label="Destination"
+                    value={destination ?? "Unavailable"}
+                    mono
+                  />
+                  <DetailRow
+                    label="Memo"
+                    value={invoice.memo ?? "Unavailable"}
+                    mono
+                  />
+                  {invoice.description ? (
+                    <DetailRow label="Context" value={invoice.description} />
+                  ) : null}
+                </View>
+
+                <View className="mt-4 rounded-3xl border border-dashed border-white/15 bg-black/20 p-4">
+                  <Text
+                    className="text-xs uppercase tracking-[0.24em] text-slate-400"
+                    style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+                  >
+                    Payment link
+                  </Text>
+                  <Text
+                    selectable
+                    className="mt-2 text-sm text-white"
+                    style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+                  >
+                    {paymentUri ??
+                      "Destination is required before we can generate a wallet link."}
+                  </Text>
+                </View>
+              </View>
             </View>
           ) : (
             <Text
@@ -151,5 +267,36 @@ export default function InvoiceDetailScreen() {
         </View>
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <View className="gap-1">
+      <Text
+        className="text-xs uppercase tracking-[0.22em] text-slate-400"
+        style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+      >
+        {label}
+      </Text>
+      <Text
+        className="text-base text-white"
+        style={{
+          fontFamily: mono
+            ? "SpaceGrotesk_500Medium"
+            : "SpaceGrotesk_400Regular",
+        }}
+      >
+        {value}
+      </Text>
+    </View>
   );
 }

--- a/mobile/lib/invoices.ts
+++ b/mobile/lib/invoices.ts
@@ -12,10 +12,14 @@ export interface Invoice {
   clientEmail?: string;
   description?: string;
   amount: number;
-  asset: string;
+  asset?: string;
+  asset_code?: string;
+  asset_issuer?: string;
   memo?: string;
+  memo_type?: string;
   status: InvoiceStatus;
   destination?: string;
+  destination_address?: string;
   createdAt: string;
   updatedAt?: string;
   dueDate?: string;

--- a/mobile/lib/payment-link.ts
+++ b/mobile/lib/payment-link.ts
@@ -1,0 +1,105 @@
+import type { Invoice } from "./invoices";
+
+type PaymentLinkParams = {
+  amount?: string;
+  assetCode?: string;
+  assetIssuer?: string;
+  destination: string;
+  memo?: string;
+  memoType?: "text" | "id" | "hash" | "return";
+};
+
+export function getInvoiceAsset(invoice: Invoice): string {
+  return invoice.asset_code ?? invoice.asset ?? "XLM";
+}
+
+export function getInvoiceDestination(invoice: Invoice): string | undefined {
+  return invoice.destination_address ?? invoice.destination;
+}
+
+export function getInvoiceMemoType(
+  invoice: Invoice,
+): "text" | "id" | "hash" | "return" {
+  const memoType = invoice.memo_type?.toLowerCase();
+
+  if (
+    memoType === "text" ||
+    memoType === "id" ||
+    memoType === "hash" ||
+    memoType === "return"
+  ) {
+    return memoType;
+  }
+
+  return "id";
+}
+
+export function generatePaymentUri({
+  amount,
+  assetCode,
+  assetIssuer,
+  destination,
+  memo,
+  memoType = "id",
+}: PaymentLinkParams): string {
+  const queryParts = [`destination=${encodeURIComponent(destination)}`];
+
+  if (amount) {
+    queryParts.push(`amount=${encodeURIComponent(amount)}`);
+  }
+
+  if (assetCode) {
+    queryParts.push(`asset_code=${encodeURIComponent(assetCode)}`);
+  }
+
+  if (assetIssuer) {
+    queryParts.push(`asset_issuer=${encodeURIComponent(assetIssuer)}`);
+  }
+
+  if (memo) {
+    queryParts.push(`memo=${encodeURIComponent(memo)}`);
+    queryParts.push(`memo_type=${memoType}`);
+  }
+
+  return `web+stellar:pay?${queryParts.join("&")}`;
+}
+
+function formatAmount(amount: number): string {
+  return amount.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+  });
+}
+
+export function buildInvoiceShareMessage(invoice: Invoice): string {
+  const assetCode = getInvoiceAsset(invoice);
+  const destination = getInvoiceDestination(invoice);
+  const paymentUri = destination
+    ? generatePaymentUri({
+        amount: String(invoice.amount),
+        assetCode,
+        assetIssuer: invoice.asset_issuer,
+        destination,
+        memo: invoice.memo,
+        memoType: getInvoiceMemoType(invoice),
+      })
+    : undefined;
+
+  const lines = [
+    `Invoice ${invoice.invoiceNumber ?? invoice.id}`,
+    invoice.clientName ?? "Payment request",
+    "",
+    `Amount: ${formatAmount(invoice.amount)} ${assetCode}`,
+    `Destination: ${destination ?? "Unavailable"}`,
+    `Memo: ${invoice.memo ?? "Unavailable"}`,
+  ];
+
+  if (invoice.description) {
+    lines.push(`Context: ${invoice.description}`);
+  }
+
+  if (paymentUri) {
+    lines.push("", `Payment link: ${paymentUri}`);
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
closes #148
Added native invoice sharing and a screenshot-friendly payment card on the mobile invoice detail screen.
The main changes are in [mobile/app/invoices/[id\].tsx](/Users/macbook/grantfox/Invoisio/mobile/app/invoices/[id].tsx), [mobile/lib/payment-link.ts](/Users/macbook/grantfox/Invoisio/mobile/lib/payment-link.ts), and [mobile/lib/invoices.ts](/Users/macbook/grantfox/Invoisio/mobile/lib/invoices.ts). The detail screen now:
opens the native Share sheet on iOS and Android
shares a payload containing amount, asset, destination, memo, description/context, and a generated web+stellar:pay link
shows a dedicated “share-ready payment card” with destination, amount, memo, and payment link laid out cleanly for screenshots
I also updated the mobile invoice type to handle the backend’s Stellar-style fields like asset_code, asset_issuer, memo_type, and destination_address, so the shared content matches the real payment instruction data instead of relying on the older simplified shape.