### PR TITLE
Implement admin dashboard analytics endpoints for invoice and payment…

### DIFF
--- a/backend/prisma/migrations/20260618000000_add_is_admin_field_to_user/migration.sql
+++ b/backend/prisma/migrations/20260618000000_add_is_admin_field_to_user/migration.sql
@@ -1,0 +1,4 @@
+-- CreateExtension
+-- AddColumn
+-- AddColumn
+ALTER TABLE "users" ADD COLUMN "is_admin" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,14 +33,15 @@ model User {
   email          String?
   nonce          String?
   nonceExpiresAt BigInt?
+  isAdmin        Boolean   @default(false) @map("is_admin")
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
   webhookUrl     String?   @map("webhook_url")
   webhookSecret  String?   @map("webhook_secret")
 
-  invoices Invoice[]
-  webhooks WebhookDelivery[]
+  invoices       Invoice[]
+  webhooks       WebhookDelivery[]
 
   @@index([merchantId])
   @@map("users")

--- a/backend/src/admin-analytics/admin-analytics.controller.ts
+++ b/backend/src/admin-analytics/admin-analytics.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query, UseGuards } from "@nestjs/common";
+import { AdminAnalyticsService } from "./admin-analytics.service";
+import { AdminGuard } from "../auth/guard/admin.guard";
+import { InvoiceAnalyticsQueryDto } from "./dto/invoice-analytics.dto";
+import { PaymentAnalyticsQueryDto } from "./dto/payment-analytics.dto";
+
+@Controller("admin/analytics")
+@UseGuards(AdminGuard)
+export class AdminAnalyticsController {
+  constructor(private readonly adminAnalyticsService: AdminAnalyticsService) {}
+
+  @Get("invoices")
+  async getInvoiceAnalytics(@Query() query: InvoiceAnalyticsQueryDto) {
+    return this.adminAnalyticsService.getInvoiceAnalytics(
+      query.status,
+      query.startDate,
+      query.endDate,
+    );
+  }
+
+  @Get("payments")
+  async getPaymentAnalytics(@Query() query: PaymentAnalyticsQueryDto) {
+    return this.adminAnalyticsService.getPaymentAnalytics(
+      query.asset,
+      query.startDate,
+      query.endDate,
+    );
+  }
+}

--- a/backend/src/admin-analytics/admin-analytics.module.ts
+++ b/backend/src/admin-analytics/admin-analytics.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { AdminAnalyticsController } from "./admin-analytics.controller";
+import { AdminAnalyticsService } from "./admin-analytics.service";
+import { PrismaModule } from "../prisma/prisma.module";
+import { AuthModule } from "../auth/auth.module";
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [AdminAnalyticsController],
+  providers: [AdminAnalyticsService],
+})
+export class AdminAnalyticsModule {}

--- a/backend/src/admin-analytics/admin-analytics.service.spec.ts
+++ b/backend/src/admin-analytics/admin-analytics.service.spec.ts
@@ -1,0 +1,244 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AdminAnalyticsService } from "./admin-analytics.service";
+import { PrismaService } from "../prisma/prisma.service";
+import { InvoiceStatus } from "@prisma/client";
+import { BadRequestException } from "@nestjs/common";
+
+describe("AdminAnalyticsService", () => {
+  let service: AdminAnalyticsService;
+
+  const mockPrisma = () => {
+    const invoices = [
+      {
+        id: "invoice-1",
+        merchantId: "merchant-1",
+        userId: "user-1",
+        invoiceNumber: "INV-001",
+        clientName: "Test Client 1",
+        clientEmail: "test1@example.com",
+        amount: 100,
+        assetCode: "XLM",
+        assetIssuer: null,
+        status: "paid",
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-02"),
+      },
+      {
+        id: "invoice-2",
+        merchantId: "merchant-2",
+        userId: "user-2",
+        invoiceNumber: "INV-002",
+        clientName: "Test Client 2",
+        clientEmail: "test2@example.com",
+        amount: 200,
+        assetCode: "USDC",
+        assetIssuer: "GASDF",
+        status: "pending",
+        createdAt: new Date("2024-01-15"),
+        updatedAt: new Date("2024-01-15"),
+      },
+      {
+        id: "invoice-3",
+        merchantId: "merchant-1",
+        userId: "user-1",
+        invoiceNumber: "INV-003",
+        clientName: "Test Client 3",
+        clientEmail: "test3@example.com",
+        amount: 150,
+        assetCode: "USDC",
+        assetIssuer: "GASDF",
+        status: "paid",
+        createdAt: new Date("2024-02-01"),
+        updatedAt: new Date("2024-02-02"),
+      },
+    ];
+
+    return {
+      invoice: {
+        count: jest.fn().mockImplementation(({ where }: any) => {
+          const filtered = invoices.filter((inv) => {
+            let matches = true;
+            if (where?.status && inv.status !== where.status) matches = false;
+            if (where?.assetCode && inv.assetCode !== where.assetCode)
+              matches = false;
+            if (
+              where?.createdAt?.gte &&
+              inv.createdAt.getTime() < new Date(where.createdAt.gte).getTime()
+            )
+              matches = false;
+            if (
+              where?.createdAt?.lte &&
+              inv.createdAt.getTime() > new Date(where.createdAt.lte).getTime()
+            )
+              matches = false;
+            if (
+              where?.updatedAt?.gte &&
+              inv.updatedAt.getTime() < new Date(where.updatedAt.gte).getTime()
+            )
+              matches = false;
+            if (
+              where?.updatedAt?.lte &&
+              inv.updatedAt.getTime() > new Date(where.updatedAt.lte).getTime()
+            )
+              matches = false;
+            return matches;
+          });
+          return Promise.resolve(filtered.length);
+        }),
+        aggregate: jest.fn().mockImplementation(({ where, _sum }: any) => {
+          const filtered = invoices.filter((inv) => {
+            let matches = true;
+            if (where?.status && inv.status !== where.status) matches = false;
+            if (where?.assetCode && inv.assetCode !== where.assetCode)
+              matches = false;
+            if (
+              where?.createdAt?.gte &&
+              inv.createdAt.getTime() < new Date(where.createdAt.gte).getTime()
+            )
+              matches = false;
+            if (
+              where?.createdAt?.lte &&
+              inv.createdAt.getTime() > new Date(where.createdAt.lte).getTime()
+            )
+              matches = false;
+            if (
+              where?.updatedAt?.gte &&
+              inv.updatedAt.getTime() < new Date(where.updatedAt.gte).getTime()
+            )
+              matches = false;
+            if (
+              where?.updatedAt?.lte &&
+              inv.updatedAt.getTime() > new Date(where.updatedAt.lte).getTime()
+            )
+              matches = false;
+            return matches;
+          });
+          const sum = filtered.reduce((acc, inv) => acc + inv.amount, 0);
+          return Promise.resolve({
+            _sum: { amount: { toNumber: () => sum } },
+          });
+        }),
+        groupBy: jest
+          .fn()
+          .mockImplementation(({ where, by, _count, _sum }: any) => {
+            const filtered = invoices.filter((inv) => {
+              let matches = true;
+              if (where?.status && inv.status !== where.status) matches = false;
+              if (where?.assetCode && inv.assetCode !== where.assetCode)
+                matches = false;
+              if (
+                where?.createdAt?.gte &&
+                inv.createdAt.getTime() <
+                  new Date(where.createdAt.gte).getTime()
+              )
+                matches = false;
+              if (
+                where?.createdAt?.lte &&
+                inv.createdAt.getTime() >
+                  new Date(where.createdAt.lte).getTime()
+              )
+                matches = false;
+              if (
+                where?.updatedAt?.gte &&
+                inv.updatedAt.getTime() <
+                  new Date(where.updatedAt.gte).getTime()
+              )
+                matches = false;
+              if (
+                where?.updatedAt?.lte &&
+                inv.updatedAt.getTime() >
+                  new Date(where.updatedAt.lte).getTime()
+              )
+                matches = false;
+              return matches;
+            });
+
+            const groups: any[] = [];
+            const groupMap = new Map();
+
+            for (const inv of filtered) {
+              const key = by
+                .map((b: string) => `${b}:${(inv as any)[b]}`)
+                .join("|");
+              if (!groupMap.has(key)) {
+                const group: any = { _count: 0, _sum: { amount: 0 } };
+                by.forEach((b: string) => {
+                  group[b] = (inv as any)[b];
+                });
+                groupMap.set(key, group);
+              }
+              const group = groupMap.get(key)!;
+              group._count++;
+              group._sum.amount += inv.amount;
+            }
+
+            return Promise.resolve(
+              Array.from(groupMap.values()).map((g: any) => ({
+                ...g,
+                _sum: { amount: { toNumber: () => g._sum.amount } },
+              })),
+            );
+          }),
+      },
+    };
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminAnalyticsService,
+        { provide: PrismaService, useFactory: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<AdminAnalyticsService>(AdminAnalyticsService);
+  });
+
+  it("is defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("getInvoiceAnalytics", () => {
+    it("returns total invoice count and amount", async () => {
+      const result = await service.getInvoiceAnalytics();
+      expect(result.count).toBe(3);
+      expect(result.totalAmount).toBe(450);
+    });
+
+    it("filters by status", async () => {
+      const result = await service.getInvoiceAnalytics(InvoiceStatus.paid);
+      expect(result.count).toBe(2);
+      expect(result.totalAmount).toBe(250);
+    });
+
+    it("filters by date range", async () => {
+      const result = await service.getInvoiceAnalytics(
+        undefined,
+        "2024-01-01",
+        "2024-01-31",
+      );
+      expect(result.count).toBe(2);
+      expect(result.totalAmount).toBe(300);
+    });
+
+    it("throws BadRequestException if startDate > endDate", async () => {
+      await expect(
+        service.getInvoiceAnalytics(undefined, "2024-02-01", "2024-01-01"),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe("getPaymentAnalytics", () => {
+    it("returns total payment count and volume", async () => {
+      const result = await service.getPaymentAnalytics();
+      expect(result.count).toBe(2);
+      expect(result.totalVolume).toBe(250);
+    });
+
+    it("filters by asset", async () => {
+      const result = await service.getPaymentAnalytics("USDC");
+      expect(result.count).toBe(1);
+      expect(result.totalVolume).toBe(150);
+    });
+  });
+});

--- a/backend/src/admin-analytics/admin-analytics.service.ts
+++ b/backend/src/admin-analytics/admin-analytics.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, BadRequestException } from "@nestjs/common";
+import { PrismaService } from "../prisma/prisma.service";
+import { InvoiceStatus } from "@prisma/client";
+
+@Injectable()
+export class AdminAnalyticsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getInvoiceAnalytics(
+    status?: InvoiceStatus,
+    startDate?: string,
+    endDate?: string,
+  ) {
+    const where: any = {};
+
+    if (status) {
+      where.status = status;
+    }
+
+    if (startDate || endDate) {
+      where.createdAt = {};
+      if (startDate) {
+        const start = new Date(startDate);
+        if (isNaN(start.getTime())) {
+          throw new BadRequestException("Invalid startDate");
+        }
+        where.createdAt.gte = start;
+      }
+      if (endDate) {
+        const end = new Date(endDate);
+        if (isNaN(end.getTime())) {
+          throw new BadRequestException("Invalid endDate");
+        }
+        where.createdAt.lte = end;
+      }
+      if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
+        throw new BadRequestException("startDate must be before endDate");
+      }
+    }
+
+    const [countResult, totalResult, statusBreakdown] = await Promise.all([
+      this.prisma.invoice.count({ where }),
+      this.prisma.invoice.aggregate({
+        where,
+        _sum: { amount: true },
+      }),
+      this.prisma.invoice.groupBy({
+        where,
+        by: ["status"],
+        _count: true,
+        _sum: { amount: true },
+      }),
+    ]);
+
+    return {
+      count: countResult,
+      totalAmount: totalResult._sum.amount?.toNumber() || 0,
+      statusBreakdown: statusBreakdown.map((item) => ({
+        status: item.status,
+        count: item._count,
+        totalAmount: item._sum.amount?.toNumber() || 0,
+      })),
+    };
+  }
+
+  async getPaymentAnalytics(
+    asset?: string,
+    startDate?: string,
+    endDate?: string,
+  ) {
+    const where: any = { status: InvoiceStatus.paid };
+
+    if (asset) {
+      where.assetCode = asset;
+    }
+
+    if (startDate || endDate) {
+      where.updatedAt = {};
+      if (startDate) {
+        const start = new Date(startDate);
+        if (isNaN(start.getTime())) {
+          throw new BadRequestException("Invalid startDate");
+        }
+        where.updatedAt.gte = start;
+      }
+      if (endDate) {
+        const end = new Date(endDate);
+        if (isNaN(end.getTime())) {
+          throw new BadRequestException("Invalid endDate");
+        }
+        where.updatedAt.lte = end;
+      }
+      if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
+        throw new BadRequestException("startDate must be before endDate");
+      }
+    }
+
+    const [countResult, totalResult, assetBreakdown] = await Promise.all([
+      this.prisma.invoice.count({ where }),
+      this.prisma.invoice.aggregate({
+        where,
+        _sum: { amount: true },
+      }),
+      this.prisma.invoice.groupBy({
+        where,
+        by: ["assetCode", "assetIssuer"],
+        _count: true,
+        _sum: { amount: true },
+      }),
+    ]);
+
+    return {
+      count: countResult,
+      totalVolume: totalResult._sum.amount?.toNumber() || 0,
+      assetBreakdown: assetBreakdown.map((item) => ({
+        assetCode: item.assetCode,
+        assetIssuer: item.assetIssuer,
+        count: item._count,
+        volume: item._sum.amount?.toNumber() || 0,
+      })),
+    };
+  }
+}

--- a/backend/src/admin-analytics/dto/invoice-analytics.dto.ts
+++ b/backend/src/admin-analytics/dto/invoice-analytics.dto.ts
@@ -1,0 +1,16 @@
+import { IsDateString, IsOptional, IsEnum } from "class-validator";
+import { InvoiceStatus } from "@prisma/client";
+
+export class InvoiceAnalyticsQueryDto {
+  @IsOptional()
+  @IsEnum(InvoiceStatus)
+  status?: InvoiceStatus;
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}

--- a/backend/src/admin-analytics/dto/payment-analytics.dto.ts
+++ b/backend/src/admin-analytics/dto/payment-analytics.dto.ts
@@ -1,0 +1,15 @@
+import { IsDateString, IsOptional, IsString } from "class-validator";
+
+export class PaymentAnalyticsQueryDto {
+  @IsOptional()
+  @IsString()
+  asset?: string;
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { ScheduleModule } from "@nestjs/schedule";
 import { WebhooksModule } from "./webhooks/webhooks.module";
 import { CustomThrottlerModule } from "./throttler/throttler.module";
 import { BackfillModule } from "./backfill/backfill.module";
+import { AdminAnalyticsModule } from "./admin-analytics/admin-analytics.module";
 
 /**
  * Root application module
@@ -85,6 +86,7 @@ import { BackfillModule } from "./backfill/backfill.module";
     UsersModule,
     WebhooksModule,
     BackfillModule,
+    AdminAnalyticsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/auth/guard/admin.guard.ts
+++ b/backend/src/auth/guard/admin.guard.ts
@@ -1,0 +1,23 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from "@nestjs/common";
+import { JwtAuthGuard } from "./auth.guard";
+
+@Injectable()
+export class AdminGuard extends JwtAuthGuard implements CanActivate {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user?.isAdmin) {
+      throw new ForbiddenException("Admin access required.");
+    }
+
+    return true;
+  }
+}

--- a/backend/src/auth/guard/auth.guard.ts
+++ b/backend/src/auth/guard/auth.guard.ts
@@ -22,7 +22,7 @@ export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);
  */
 @Injectable()
 export class JwtAuthGuard extends AuthGuard("jwt") implements CanActivate {
-  constructor(private readonly reflector: Reflector) {
+  constructor(protected readonly reflector: Reflector) {
     super();
   }
 

--- a/backend/src/auth/strategy/jwt.strategy.ts
+++ b/backend/src/auth/strategy/jwt.strategy.ts
@@ -38,6 +38,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       createdAt: user.createdAt,
       updatedAt: user.updatedAt,
       email: user.email,
+      isAdmin: user.isAdmin,
     } as any;
   }
 }

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -11,6 +11,8 @@ export class User {
 
   nonceExpiresAt?: number | bigint | null;
 
+  isAdmin: boolean;
+
   createdAt?: Date;
 
   updatedAt?: Date;


### PR DESCRIPTION
## Pull Request: Implement Admin Dashboard Analytics Endpoints (closes #101)

### Summary
This PR adds protected admin-only endpoints to get invoice and payment analytics for the Invoisio dashboard!

### Changes Made
- **Updated User Model and Entity**: Added an `isAdmin` boolean field (default: false) to the User model in `prisma/schema.prisma` and updated the User entity in `src/users/user.entity.ts`
- **Created Admin Guard (`src/auth/guard/admin.guard.ts`)**: Extends JwtAuthGuard, checking for `isAdmin` on the user and throwing 403 Forbidden error if not admin
- **Modified JwtAuthGuard (`src/auth/guard/auth.guard.ts`)**: Changed `private readonly reflector` to `protected readonly reflector` for subclass access
- **Updated JWT Strategy (`src/auth/strategy/jwt.strategy.ts`)**: Added `isAdmin` to the User object returned from validation
- **Created Admin Analytics Module (`src/admin-analytics/`)**:
  - **DTOs**: Added query parameter validation for both endpoints in `dto/invoice-analytics.dto.ts` and `dto/payment-analytics.dto.ts`
  - **Service (`admin-analytics.service.ts`)**:
    - `getInvoiceAnalytics`: Returns invoice count, total amount, and status breakdown using Prisma aggregations
    - `getPaymentAnalytics`: Returns paid invoice count, total volume, and asset breakdown using Prisma aggregations
  - **Controller (`admin-analytics.controller.ts`)**: Exposes:
    - GET `/admin/analytics/invoices` with optional `status`, `startDate`, `endDate` query params
    - GET `/admin/analytics/payments` with optional `asset`, `startDate`, `endDate` query params
  - **Added Unit Tests**: `admin-analytics.service.spec.ts` has comprehensive coverage of the service
  - **Module (`admin-analytics.module.ts`)**: Added to AppModule imports
- **Added Prisma Migration File**: 20260618000000_add_is_admin_field_to_user

### Acceptance Criteria
✅ Endpoints protected by admin role guard (403 Forbidden for non-admins)
✅ Query params are validated, invalid dates return 400 Bad Request
✅ Uses efficient Prisma aggregations for queries
✅ All existing 94 unit tests pass
✅ Build compiles cleanly
✅ Linting and formatting passes
