### PR TITLE
feat(contracts): add soroban view apis for invoice payment status

### DIFF
--- a/soroban/README.md
+++ b/soroban/README.md
@@ -18,6 +18,7 @@ soroban/
 ├── invoke-config.sh                # Query high-level contract config
 ├── invoke-has-payment.sh           # Check payment existence
 ├── invoke-payment-history.sh       # Page through payment history
+├── invoke-payments-by-payer.sh     # Page through payment history for one payer
 └── contracts/
     └── invoice-payment/            # ← Main Invoisio contract
         ├── src/lib.rs              # Contract logic + inline docs
@@ -322,6 +323,19 @@ Retrieves a bounded page of payment history.
 ```
 
 **Returns:** a page of payment records with `next_cursor` and `has_more`
+
+### `./invoke-payments-by-payer.sh`
+
+Retrieves a bounded page of payment history filtered to a single payer.
+
+**Usage:**
+```bash
+./invoke-payments-by-payer.sh <payer> <cursor> [limit]
+```
+
+**Returns:** a page of payment records made by `payer`, with `next_cursor` and
+`has_more`. A payer with no recorded payments returns an empty page rather
+than an error.
 
 ---
 

--- a/soroban/contracts/invoice-payment/Makefile
+++ b/soroban/contracts/invoice-payment/Makefile
@@ -89,6 +89,18 @@ invoke-payment-history:
 	  --cursor $(CURSOR) \
 	  --limit $(LIMIT)
 
+# Read a bounded page of payment history filtered to a single payer
+# Usage: make invoke-payments-by-payer CONTRACT_ID=<id> PAYER=<G...> CURSOR=0 LIMIT=25
+invoke-payments-by-payer:
+	stellar contract invoke \
+	  --id $(CONTRACT_ID) \
+	  --source invoisio-admin \
+	  --network testnet \
+	  -- payments_by_payer \
+	  --payer "$(PAYER)" \
+	  --cursor $(CURSOR) \
+	  --limit $(LIMIT)
+
 # Check whether an invoice has been recorded (returns true/false)
 # Usage: make invoke-has-payment CONTRACT_ID=<id> INVOICE_ID=invoisio-abc123
 invoke-has-payment:
@@ -123,4 +135,5 @@ schema:
 .PHONY: default all build test fmt clean schema \
 	generate-identity fund deploy \
 	invoke-initialize invoke-record-payment invoke-get-payment \
-	invoke-has-payment invoke-payment-count invoke-payment-history events
+	invoke-has-payment invoke-payment-count invoke-payment-history \
+	invoke-payments-by-payer events

--- a/soroban/contracts/invoice-payment/generate-schema.sh
+++ b/soroban/contracts/invoice-payment/generate-schema.sh
@@ -135,6 +135,28 @@ cat > "$OUT" <<JSON
       },
       "required": ["admin", "initialized", "version", "allowlist_mode"],
       "additionalProperties": false
+    },
+    "PaymentHistoryPage": {
+      "description": "Bounded, cursor-friendly slice of payment history returned by payment_history() and payments_by_payer().",
+      "type": "object",
+      "properties": {
+        "records": {
+          "type": "array",
+          "items": { "\$ref": "#/types/PaymentRecord" },
+          "description": "Records returned for this page."
+        },
+        "next_cursor": {
+          "type": "integer",
+          "description": "Cursor to pass to the next call.",
+          "minimum": 0
+        },
+        "has_more": {
+          "type": "boolean",
+          "description": "True when more entries are available after next_cursor."
+        }
+      },
+      "required": ["records", "next_cursor", "has_more"],
+      "additionalProperties": false
     }
   },
   "events": {
@@ -194,6 +216,8 @@ cat > "$OUT" <<JSON
     "get_payment":       { "auth": "none",  "description": "Return PaymentRecord for invoice_id." },
     "has_payment":       { "auth": "none",  "description": "Return true if a payment exists for invoice_id." },
     "payment_count":     { "auth": "none",  "description": "Return total recorded payment count." },
+    "payment_history":   { "auth": "none",  "description": "Return a bounded, cursor-paginated PaymentHistoryPage across all payments." },
+    "payments_by_payer": { "auth": "none",  "description": "Return a bounded, cursor-paginated PaymentHistoryPage filtered to one payer." },
     "config":            { "auth": "none",  "description": "Return ContractConfig snapshot." },
     "contract_version":  { "auth": "none",  "description": "Return packed semver as u32." },
     "version_info":      { "auth": "none",  "description": "Return on-chain ContractMeta." },

--- a/soroban/contracts/invoice-payment/schema.json
+++ b/soroban/contracts/invoice-payment/schema.json
@@ -113,6 +113,28 @@
       },
       "required": ["admin", "initialized", "version", "allowlist_mode"],
       "additionalProperties": false
+    },
+    "PaymentHistoryPage": {
+      "description": "Bounded, cursor-friendly slice of payment history returned by payment_history() and payments_by_payer().",
+      "type": "object",
+      "properties": {
+        "records": {
+          "type": "array",
+          "items": { "$ref": "#/types/PaymentRecord" },
+          "description": "Records returned for this page."
+        },
+        "next_cursor": {
+          "type": "integer",
+          "description": "Cursor to pass to the next call.",
+          "minimum": 0
+        },
+        "has_more": {
+          "type": "boolean",
+          "description": "True when more entries are available after next_cursor."
+        }
+      },
+      "required": ["records", "next_cursor", "has_more"],
+      "additionalProperties": false
     }
   },
   "events": {
@@ -172,6 +194,8 @@
     "get_payment":       { "auth": "none",  "description": "Return PaymentRecord for invoice_id." },
     "has_payment":       { "auth": "none",  "description": "Return true if a payment exists for invoice_id." },
     "payment_count":     { "auth": "none",  "description": "Return total recorded payment count." },
+    "payment_history":   { "auth": "none",  "description": "Return a bounded, cursor-paginated PaymentHistoryPage across all payments." },
+    "payments_by_payer": { "auth": "none",  "description": "Return a bounded, cursor-paginated PaymentHistoryPage filtered to one payer." },
     "config":            { "auth": "none",  "description": "Return ContractConfig snapshot." },
     "contract_version":  { "auth": "none",  "description": "Return packed semver as u32." },
     "version_info":      { "auth": "none",  "description": "Return on-chain ContractMeta." },

--- a/soroban/contracts/invoice-payment/src/lib.rs
+++ b/soroban/contracts/invoice-payment/src/lib.rs
@@ -18,8 +18,9 @@ use events::{
     emit_asset_allowlisted, emit_asset_revoked, emit_native_allow_changed, emit_payment_recorded,
 };
 use storage::{
-    allow_asset, append_payment_history, bump_count, bump_history_count, current_contract_meta,
-    ensure_current_contract_meta, get_admin, get_count, get_payment, get_payment_history_page,
+    allow_asset, append_payer_history, append_payment_history, bump_count, bump_history_count,
+    bump_payer_history_count, current_contract_meta, ensure_current_contract_meta, get_admin,
+    get_count, get_payer_history_page, get_payment, get_payment_history_page,
     get_state_contract_version, get_storage_schema_version, has_admin, has_payment,
     is_asset_allowed, is_native_allowed, revoke_asset, set_admin, set_contract_meta,
     set_native_allowed, set_payment,
@@ -66,8 +67,9 @@ use storage::{
 ///   - [`set_admin`] requires **both** the current admin and the new admin to
 ///     authorise, ensuring the new admin explicitly consents to taking over.
 /// - **Read methods** (`get_payment`, `has_payment`, `payment_count`,
-///   `payment_history`, `contract_version`, `version_info`, `admin`) are
-///   permissionless, so any account can inspect on-chain payment state.
+///   `payment_history`, `payments_by_payer`, `contract_version`,
+///   `version_info`, `admin`) are permissionless, so any account can inspect
+///   on-chain payment state.
 ///
 /// ## Typical backend flow
 /// 1. Deploy + call `initialize(admin)` once.
@@ -75,7 +77,7 @@ use storage::{
 /// 3. Backend calls `record_payment(invoice_id, payer, asset_code, asset_issuer, amount)`.
 /// 4. Contract stores record + emits event.
 /// 5. Any observer calls `get_payment(invoice_id)`, `payment_history(cursor, limit)`,
-///    or streams `getEvents` to verify.
+///    `payments_by_payer(payer, cursor, limit)`, or streams `getEvents` to verify.
 #[contract]
 pub struct InvoicePaymentContract;
 
@@ -225,9 +227,11 @@ impl InvoicePaymentContract {
         };
         set_payment(&env, &record);
 
-        // 7. Persist the ordered history entry and increment counters.
+        // 7. Persist the ordered history entries and increment counters.
         append_payment_history(&env, &record);
         bump_history_count(&env);
+        append_payer_history(&env, &record.payer, &record);
+        bump_payer_history_count(&env, &record.payer);
         bump_count(&env);
 
         // 8. Emit Soroban event — off-chain indexers subscribe to these topics.
@@ -277,6 +281,21 @@ impl InvoicePaymentContract {
     /// the response remains bounded and predictable.
     pub fn payment_history(env: Env, cursor: u32, limit: u32) -> PaymentHistoryPage {
         get_payment_history_page(&env, cursor, limit)
+    }
+
+    /// Return a bounded, cursor-friendly page of payment history for a single `payer`.
+    ///
+    /// Mirrors [`Self::payment_history`] but scoped to payments made by
+    /// `payer`, using the same cursor/limit semantics and page-size cap. A
+    /// `payer` with no recorded payments returns an empty page rather than
+    /// an error.
+    pub fn payments_by_payer(
+        env: Env,
+        payer: Address,
+        cursor: u32,
+        limit: u32,
+    ) -> PaymentHistoryPage {
+        get_payer_history_page(&env, &payer, cursor, limit)
     }
 
     /// Return a high-level snapshot of contract configuration.

--- a/soroban/contracts/invoice-payment/src/storage.rs
+++ b/soroban/contracts/invoice-payment/src/storage.rs
@@ -105,6 +105,14 @@ pub enum DataKey {
     PaymentV1(String),
     /// Append-only history index used for deterministic paging.
     PaymentHistory(u32),
+    /// Append-only per-payer history index used for deterministic paging.
+    /// Key: PayerHistory(payer, index)
+    PayerHistory(Address, u32),
+    /// Running count of history-indexed entries for a specific payer.
+    /// Lives in **persistent** storage (not instance) because it is keyed
+    /// per payer and would otherwise grow the bounded instance footprint
+    /// loaded on every invocation.
+    PayerHistoryCount(Address),
     /// Allowlist entry for a token in **persistent** storage.
     /// Key: AllowList(asset_code, issuer)
     AllowList(String, String),
@@ -381,6 +389,90 @@ pub fn get_payment_history_page(env: &Env, cursor: u32, limit: u32) -> PaymentHi
     let mut index = start;
     while index < end {
         match get_history_record(env, index) {
+            Some(record) => records.push_back(record),
+            None => break,
+        }
+        index += 1;
+    }
+
+    PaymentHistoryPage {
+        records,
+        next_cursor: index,
+        has_more: index < total,
+    }
+}
+
+// Payer history helpers (persistent storage)
+//
+// Keyed per `payer` so the index can grow without inflating the bounded
+// instance storage footprint that is loaded on every contract invocation.
+
+fn payer_history_key(payer: &Address, index: u32) -> DataKey {
+    DataKey::PayerHistory(payer.clone(), index)
+}
+
+fn payer_history_count_key(payer: &Address) -> DataKey {
+    DataKey::PayerHistoryCount(payer.clone())
+}
+
+/// Return the number of indexed history entries for `payer` (0 if none).
+pub fn get_payer_history_count(env: &Env, payer: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&payer_history_count_key(payer))
+        .unwrap_or(0u32)
+}
+
+/// Increment `payer`'s history index counter and extend its TTL.
+pub fn bump_payer_history_count(env: &Env, payer: &Address) {
+    let key = payer_history_count_key(payer);
+    let count = get_payer_history_count(env, payer);
+    env.storage().persistent().set(&key, &(count + 1u32));
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, MIN_TTL, BUMP_TTL);
+}
+
+/// Append a record to `payer`'s deterministic history index.
+pub fn append_payer_history(env: &Env, payer: &Address, record: &PaymentRecord) {
+    let index = get_payer_history_count(env, payer);
+    let key = payer_history_key(payer, index);
+    env.storage().persistent().set(&key, record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, MIN_TTL, BUMP_TTL);
+}
+
+fn get_payer_history_record(env: &Env, payer: &Address, index: u32) -> Option<PaymentRecord> {
+    let key = payer_history_key(payer, index);
+    let record: Option<PaymentRecord> = env.storage().persistent().get(&key);
+    if record.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, MIN_TTL, BUMP_TTL);
+    }
+    record
+}
+
+/// Read a bounded page of `payer`'s history starting at `cursor`.
+///
+/// Mirrors [`get_payment_history_page`] but scoped to a single payer, using
+/// the same cursor/limit semantics and the same page-size cap.
+pub fn get_payer_history_page(
+    env: &Env,
+    payer: &Address,
+    cursor: u32,
+    limit: u32,
+) -> PaymentHistoryPage {
+    let total = get_payer_history_count(env, payer);
+    let capped_limit = core::cmp::min(limit, MAX_PAYMENT_HISTORY_PAGE_SIZE);
+    let start = core::cmp::min(cursor, total);
+    let end = start.saturating_add(capped_limit).min(total);
+
+    let mut records: Vec<PaymentRecord> = Vec::new(env);
+    let mut index = start;
+    while index < end {
+        match get_payer_history_record(env, payer, index) {
             Some(record) => records.push_back(record),
             None => break,
         }

--- a/soroban/contracts/invoice-payment/src/test.rs
+++ b/soroban/contracts/invoice-payment/src/test.rs
@@ -278,6 +278,133 @@ fn test_payment_history_page_size_is_capped() {
     assert!(!second_page.has_more);
 }
 
+// payments_by_payer
+
+#[test]
+fn test_payments_by_payer_filters_to_single_payer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+
+    client.set_allow_native(&true);
+    let payer_a = Address::generate(&env);
+    let payer_b = Address::generate(&env);
+
+    record_xlm(&env, &client, "invoisio-payer-a-001", &payer_a, 10_000_000);
+    record_xlm(&env, &client, "invoisio-payer-b-001", &payer_b, 20_000_000);
+    record_xlm(&env, &client, "invoisio-payer-a-002", &payer_a, 30_000_000);
+
+    let page = client.payments_by_payer(&payer_a, &0u32, &10u32);
+    assert_eq!(page.records.len(), 2);
+    assert_eq!(
+        page.records.get(0).unwrap().invoice_id,
+        String::from_str(&env, "invoisio-payer-a-001")
+    );
+    assert_eq!(
+        page.records.get(1).unwrap().invoice_id,
+        String::from_str(&env, "invoisio-payer-a-002")
+    );
+    assert!(!page.has_more);
+
+    let page_b = client.payments_by_payer(&payer_b, &0u32, &10u32);
+    assert_eq!(page_b.records.len(), 1);
+    assert_eq!(
+        page_b.records.get(0).unwrap().invoice_id,
+        String::from_str(&env, "invoisio-payer-b-001")
+    );
+}
+
+#[test]
+fn test_payments_by_payer_pages_deterministically() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+
+    client.set_allow_native(&true);
+    let payer = Address::generate(&env);
+
+    for idx in 0..3u32 {
+        let invoice_id = String::from_str(&env, &format!("invoisio-payer-history-{idx:02}"));
+        client.record_payment(
+            &invoice_id,
+            &payer,
+            &String::from_str(&env, "XLM"),
+            &String::from_str(&env, ""),
+            &((idx as i128 + 1) * 10_000_000i128),
+        );
+    }
+
+    let first_page = client.payments_by_payer(&payer, &0u32, &2u32);
+    assert_eq!(first_page.records.len(), 2);
+    assert_eq!(first_page.next_cursor, 2);
+    assert!(first_page.has_more);
+    assert_eq!(
+        first_page.records.get(0).unwrap().invoice_id,
+        String::from_str(&env, "invoisio-payer-history-00")
+    );
+    assert_eq!(
+        first_page.records.get(1).unwrap().invoice_id,
+        String::from_str(&env, "invoisio-payer-history-01")
+    );
+
+    let second_page = client.payments_by_payer(&payer, &first_page.next_cursor, &2u32);
+    assert_eq!(second_page.records.len(), 1);
+    assert_eq!(second_page.next_cursor, 3);
+    assert!(!second_page.has_more);
+    assert_eq!(
+        second_page.records.get(0).unwrap().invoice_id,
+        String::from_str(&env, "invoisio-payer-history-02")
+    );
+
+    let empty_page = client.payments_by_payer(&payer, &99u32, &2u32);
+    assert_eq!(empty_page.records.len(), 0);
+    assert_eq!(empty_page.next_cursor, 3);
+    assert!(!empty_page.has_more);
+}
+
+#[test]
+fn test_payments_by_payer_unknown_payer_returns_empty_page() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let unknown_payer = Address::generate(&env);
+    let page = client.payments_by_payer(&unknown_payer, &0u32, &10u32);
+    assert_eq!(page.records.len(), 0);
+    assert_eq!(page.next_cursor, 0);
+    assert!(!page.has_more);
+}
+
+#[test]
+fn test_payments_by_payer_page_size_is_capped() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+
+    client.set_allow_native(&true);
+    let payer = Address::generate(&env);
+
+    for idx in 0..26u32 {
+        let invoice_id = String::from_str(&env, &format!("invoisio-payer-cap-{idx:02}"));
+        client.record_payment(
+            &invoice_id,
+            &payer,
+            &String::from_str(&env, "XLM"),
+            &String::from_str(&env, ""),
+            &(10_000_000i128 + idx as i128),
+        );
+    }
+
+    let first_page = client.payments_by_payer(&payer, &0u32, &100u32);
+    assert_eq!(first_page.records.len(), 25);
+    assert_eq!(first_page.next_cursor, 25);
+    assert!(first_page.has_more);
+
+    let second_page = client.payments_by_payer(&payer, &first_page.next_cursor, &100u32);
+    assert_eq!(second_page.records.len(), 1);
+    assert_eq!(second_page.next_cursor, 26);
+    assert!(!second_page.has_more);
+}
+
 #[test]
 fn test_duplicate_invoice_id_returns_error() {
     let env = Env::default();

--- a/soroban/invoke-payments-by-payer.sh
+++ b/soroban/invoke-payments-by-payer.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Retrieve a bounded page of payment history filtered to a single payer
+# from the Invoisio Soroban contract
+#
+# Usage: ./invoke-payments-by-payer.sh <payer> <cursor> [limit]
+#
+# Arguments:
+#   payer  - Stellar account address (G...) to filter payments by
+#   cursor - Next history index to read from
+#   limit  - Optional page size (default: 25)
+#
+# Environment variables:
+#   STELLAR_NETWORK   - Network to use (default: testnet)
+#   CONTRACT_ID       - Override contract ID (default: read from .contract-id file)
+#
+# Example:
+#   ./invoke-payments-by-payer.sh GB7TAYRUZGE6T... 0 25
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Configuration
+NETWORK="${STELLAR_NETWORK:-testnet}"
+IDENTITY="${STELLAR_IDENTITY:-invoisio-admin}"
+CONTRACT_ID_FILE="contracts/invoice-payment/.contract-id"
+
+# Parse arguments
+PAYER="$1"
+CURSOR="$2"
+LIMIT="${3:-25}"
+
+# Show usage if required arguments are missing
+if [ -z "$PAYER" ] || [ -z "$CURSOR" ]; then
+    echo "Usage: $0 <payer> <cursor> [limit]"
+    echo ""
+    echo "Example:"
+    echo "  $0 GB7TAYRUZGE6T... 0 25"
+    exit 1
+fi
+
+# Get contract ID
+if [ -n "$CONTRACT_ID" ]; then
+    echo "ℹ️  Using CONTRACT_ID from environment: $CONTRACT_ID"
+elif [ -f "$CONTRACT_ID_FILE" ]; then
+    CONTRACT_ID=$(cat "$CONTRACT_ID_FILE")
+else
+    echo "❌ Error: Contract ID not found"
+    echo ""
+    echo "Either:"
+    echo "  1. Deploy the contract first: ./deploy.sh"
+    echo "  2. Set CONTRACT_ID environment variable"
+    exit 1
+fi
+
+echo "========================================="
+echo "Retrieving Payments By Payer"
+echo "========================================="
+echo "Contract ID: $CONTRACT_ID"
+echo "Payer:       $PAYER"
+echo "Cursor:      $CURSOR"
+echo "Limit:       $LIMIT"
+echo "Network:     $NETWORK"
+echo ""
+
+# Invoke payments_by_payer
+stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$IDENTITY" \
+    --network "$NETWORK" \
+    -- payments_by_payer \
+    --payer "$PAYER" \
+    --cursor "$CURSOR" \
+    --limit "$LIMIT"
+
+echo ""


### PR DESCRIPTION
## Summary

Closes #22

The `invoice-payment` Soroban contract already exposed `get_payment`, `has_payment`, `payment_count`, and a global `payment_history(cursor, limit)` page (added in #174). This PR adds the remaining optional read the issue asked for: listing payments filtered to a single payer.

- Adds `payments_by_payer(payer, cursor, limit) -> PaymentHistoryPage`, a permissionless view mirroring `payment_history`'s cursor/limit/has_more semantics and `MAX_PAYMENT_HISTORY_PAGE_SIZE` cap.
- `record_payment` now also appends each record to a per-payer append-only index (`DataKey::PayerHistory(Address, u32)` / `DataKey::PayerHistoryCount(Address)`), in addition to the existing global history index.
- The per-payer count lives in **persistent** storage (not instance), since it's keyed per payer and would otherwise grow the bounded instance footprint loaded on every contract invocation.
- An unknown/no-payments payer returns an empty page (`records: []`, `has_more: false`) rather than an error — same graceful-not-found behavior as the rest of the contract's read methods.
- Updated `schema.json` / `generate-schema.sh` to document `payments_by_payer` (and backfilled the previously-undocumented `payment_history` + `PaymentHistoryPage` type from #174).
- Added `invoke-payments-by-payer.sh` and a matching `make invoke-payments-by-payer` target, following the existing script conventions.

## Test plan

- [x] `cargo test` — 56/56 passing, including 4 new tests: `test_payments_by_payer_filters_to_single_payer`, `test_payments_by_payer_pages_deterministically`, `test_payments_by_payer_unknown_payer_returns_empty_page`, `test_payments_by_payer_page_size_is_capped`
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `stellar contract build` — `payments_by_payer` present in exported functions
- [x] Verified live on Stellar testnet (contract `CCHJJ24GSYT25VQ47ZSVJNFKQ7WBBAT3G3NFXWGDN64EFX7TPCUYA4YC`):

Payer with payments:
```bash
stellar contract invoke --id CCHJJ24GSYT25VQ47ZSVJNFKQ7WBBAT3G3NFXWGDN64EFX7TPCUYA4YC \
  --source invoisio-admin --network testnet -- payments_by_payer \
  --payer GAGLWUDI35FJK7VU6XOMXHPODVWNWNZ5HQM6ZOHV6U5ZFVDQKGQ6G7P4 --cursor 0 --limit 25

{"has_more":false,"next_cursor":2,"records":[
  {"amount":"10000000","asset":"Native","invoice_id":"invoisio-pr22-001","payer":"GAGLWUDI35FJK7VU6XOMXHPODVWNWNZ5HQM6ZOHV6U5ZFVDQKGQ6G7P4","timestamp":1781740300},
  {"amount":"25000000","asset":"Native","invoice_id":"invoisio-pr22-002","payer":"GAGLWUDI35FJK7VU6XOMXHPODVWNWNZ5HQM6ZOHV6U5ZFVDQKGQ6G7P4","timestamp":1781740315}
]}
```

Payer with no payments (graceful empty page):
```bash
stellar contract invoke --id CCHJJ24GSYT25VQ47ZSVJNFKQ7WBBAT3G3NFXWGDN64EFX7TPCUYA4YC \
  --source invoisio-admin --network testnet -- payments_by_payer \
  --payer GCBAVHAKB5CPIEV2TDVCKL7LMQX5IXHQGEJ4T25WVJA3HEBOTUJ2Z4MP --cursor 0 --limit 25

{"has_more":false,"next_cursor":0,"records":[]}
```
