### PR TITLE
feat: add cancel and void invoice endpoints (#158)

### DIFF
--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -118,4 +118,50 @@ export class InvoicesController {
       this.invoicesService.updateStatus(id, status, user.merchantId),
     );
   }
+
+  /**
+   * Cancel an unpaid invoice.
+   * Only pending or overdue invoices may be cancelled.
+   * @param id     - Invoice UUID
+   * @param reason - Optional reason string (defaults to "cancelled")
+   * @returns      - { id, status, reason, cancelledAt }
+   */
+  @Auth()
+  @Patch(":id/cancel")
+  async cancelInvoice(
+    @CurrentUser() user: User,
+    @Param("id") id: string,
+    @Body("reason") reason?: string,
+  ) {
+    return this.prisma.runWithMerchantScope(user.merchantId, () =>
+      this.invoicesService.cancelInvoice(
+        id,
+        user.merchantId,
+        reason ?? "cancelled",
+      ),
+    );
+  }
+
+  /**
+   * Void an unpaid invoice (alias for cancel with reason "voided").
+   * Semantically indicates the invoice was created in error.
+   * @param id     - Invoice UUID
+   * @param reason - Optional reason string (defaults to "voided")
+   * @returns      - { id, status, reason, cancelledAt }
+   */
+  @Auth()
+  @Patch(":id/void")
+  async voidInvoice(
+    @CurrentUser() user: User,
+    @Param("id") id: string,
+    @Body("reason") reason?: string,
+  ) {
+    return this.prisma.runWithMerchantScope(user.merchantId, () =>
+      this.invoicesService.cancelInvoice(
+        id,
+        user.merchantId,
+        reason ?? "voided",
+      ),
+    );
+  }
 }

--- a/backend/src/invoices/invoices.service.spec.ts
+++ b/backend/src/invoices/invoices.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { BadRequestException, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { InvoicesService } from "./invoices.service";
 import { StellarService } from "../stellar/stellar.service";
 import { SorobanService } from "../soroban/soroban.service";
@@ -209,6 +209,96 @@ describe("InvoicesService", () => {
       await expect(
         service.searchInvoices(undefined as any, "Acme"),
       ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  describe("cancelInvoice", () => {
+    it("cancels a pending invoice and returns status + reason", async () => {
+      const result = await service.cancelInvoice(
+        "invoice-a-1",
+        MERCHANT_A,
+        "customer request",
+      );
+      expect(result.status).toBe("cancelled");
+      expect(result.reason).toBe("customer request");
+      expect(result.id).toBe("invoice-a-1");
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it("uses default reason 'cancelled' when none is supplied", async () => {
+      const result = await service.cancelInvoice("invoice-b-1", MERCHANT_B);
+      expect(result.reason).toBe("cancelled");
+    });
+
+    it("throws NotFoundException when invoice belongs to a different merchant", async () => {
+      await expect(
+        service.cancelInvoice("invoice-b-1", MERCHANT_A),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws NotFoundException for a non-existent invoice", async () => {
+      await expect(
+        service.cancelInvoice("no-such-id", MERCHANT_A),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws BadRequestException when the invoice is already paid", async () => {
+      // First pay the invoice via updateStatus, then attempt to cancel it
+      await service.updateStatus("invoice-a-1", "paid" as any, MERCHANT_A);
+      await expect(
+        service.cancelInvoice("invoice-a-1", MERCHANT_A),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("throws BadRequestException when the invoice is already cancelled", async () => {
+      await service.cancelInvoice("invoice-a-1", MERCHANT_A);
+      await expect(
+        service.cancelInvoice("invoice-a-1", MERCHANT_A),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("enqueues a webhook after cancellation", async () => {
+      const webhookSpy = jest.spyOn(
+        (service as any).webhooksService,
+        "enqueueWebhook",
+      );
+      await service.cancelInvoice("invoice-a-1", MERCHANT_A, "test");
+      expect(webhookSpy).toHaveBeenLastCalledWith(
+        "invoice-a-1",
+        "cancelled",
+        undefined,
+        MERCHANT_A,
+      );
+    });
+  });
+
+  describe("findByMemo", () => {
+    it("returns null for a cancelled invoice (reconciliation guard)", async () => {
+      // Cancel invoice-a-1 first
+      await service.cancelInvoice("invoice-a-1", MERCHANT_A);
+      const found = await service.findByMemo("1001");
+      expect(found).toBeNull();
+    });
+
+    it("returns the invoice for a non-cancelled memo", async () => {
+      const found = await service.findByMemo("1001");
+      expect(found).not.toBeNull();
+      expect(found!.memo).toBe("1001");
+    });
+  });
+
+  describe("reconcilePayment", () => {
+    it("throws BadRequestException when attempting to pay a cancelled invoice", async () => {
+      await service.cancelInvoice("invoice-a-1", MERCHANT_A);
+      await expect(
+        service.reconcilePayment(
+          "invoice-a-1",
+          "GPAYER",
+          "XLM",
+          "",
+          "1000000",
+        ),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   Logger,
   NotFoundException,
@@ -326,6 +327,8 @@ export class InvoicesService implements OnModuleInit {
       where: { memo: memo },
     });
     if (!invoice) return null;
+    // Cancelled invoices must never be matched by the reconciliation watcher
+    if (invoice.status === "cancelled") return null;
     return this.normalizeInvoice(invoice);
   }
 
@@ -424,6 +427,13 @@ export class InvoicesService implements OnModuleInit {
       throw new NotFoundException(`Invoice with ID "${invoiceId}" not found`);
     }
 
+    // Cancelled invoices must never transition to paid through the watcher flow
+    if (invoice.status === "cancelled") {
+      throw new BadRequestException(
+        `Invoice "${invoiceId}" is cancelled and cannot be paid`,
+      );
+    }
+
     // Step 2 — idempotency gate: check if already recorded on-chain.
     const alreadyOnChain =
       await this.sorobanService.hasInvoicePayment(invoiceId);
@@ -461,6 +471,63 @@ export class InvoicesService implements OnModuleInit {
       "paid" as InvoiceStatus,
     );
     return { ...updated, txHash, ledger };
+  }
+
+  /**
+   * Cancel or void an unpaid invoice.
+   *
+   * Only invoices in `pending` or `overdue` status may be cancelled.
+   * Paid invoices cannot be reversed through this endpoint.
+   * Already-cancelled invoices are rejected to prevent duplicate webhooks.
+   *
+   * The cancellation reason and timestamp are stored in `metadata.cancellation`
+   * so they survive for audit purposes.
+   *
+   * @param id         - Invoice UUID
+   * @param merchantId - Merchant scope (enforces ownership)
+   * @param reason     - Human-readable reason string (e.g. "cancelled", "voided")
+   * @returns          - Plain object with id, status, reason, and cancelledAt
+   */
+  async cancelInvoice(
+    id: string,
+    merchantId: string,
+    reason = "cancelled",
+  ): Promise<{ id: string; status: string; reason: string; cancelledAt: Date }> {
+    const invoice = await this.prisma.invoice.findFirst({
+      where: { id, merchantId },
+    });
+
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID "${id}" not found`);
+    }
+    if (invoice.status === "paid") {
+      throw new BadRequestException("Cannot cancel a paid invoice");
+    }
+    if (invoice.status === "cancelled") {
+      throw new BadRequestException("Invoice is already cancelled");
+    }
+
+    const cancelledAt = new Date();
+
+    await this.prisma.invoice.update({
+      where: { id },
+      data: {
+        status: "cancelled",
+        metadata: {
+          ...((invoice.metadata as any) ?? {}),
+          cancellation: { reason, cancelledAt: cancelledAt.toISOString() },
+        },
+      },
+    });
+
+    await this.webhooksService.enqueueWebhook(
+      id,
+      "cancelled" as any,
+      invoice.txHash,
+      merchantId,
+    );
+
+    return { id, status: "cancelled", reason, cancelledAt };
   }
 
   /**


### PR DESCRIPTION
- Add cancelInvoice() service method; rejects paid and already-cancelled invoices

- Guard findByMemo() to return null for cancelled invoices (reconciliation skip)

- Guard reconcilePayment() to throw BadRequestException for cancelled invoices

- Add PATCH /invoices/:id/cancel endpoint (protected, returns status + reason)

- Add PATCH /invoices/:id/void endpoint (alias with reason defaulting to 'voided')

- Cancellation reason and timestamp stored in metadata.cancellation for audit trail

- Webhook enqueued on successful cancellation

- 10 new tests covering happy path, state guards, isolation, and reconciliation

closes #158 