### PR TITLE
feat(web): Point of Sale screen with QR code payment request

### DIFF
--- a/web/app/invoices/page.tsx
+++ b/web/app/invoices/page.tsx
@@ -135,6 +135,12 @@ export default function InvoicesPage() {
             >
               Refresh
             </button>
+            <Link
+              href="/pos"
+              className="inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700"
+            >
+              + Quick Sale
+            </Link>
           </div>
         </div>
 

--- a/web/app/pos/page.tsx
+++ b/web/app/pos/page.tsx
@@ -1,0 +1,321 @@
+
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { QRCodeSVG } from 'qrcode.react';
+import { apiClient, extractApiErrorMessage } from '@/lib/api-client';
+import { generatePaymentUri } from '@/lib/sep0007';
+
+// Stellar mainnet USDC issuer — override via NEXT_PUBLIC_USDC_ISSUER for testnet
+const USDC_ISSUER =
+  process.env.NEXT_PUBLIC_USDC_ISSUER ||
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+
+interface Invoice {
+  id: string;
+  invoiceNumber?: string;
+  amount: number;
+  asset: string;
+  asset_issuer?: string;
+  memo: string;
+  destination_address: string;
+  status: string;
+}
+
+type Asset = 'XLM' | 'USDC';
+
+function FormView({
+  onSuccess,
+}: {
+  onSuccess: (invoice: Invoice) => void;
+}) {
+  const [amount, setAmount] = useState('');
+  const [asset, setAsset] = useState<Asset>('XLM');
+  const [memo, setMemo] = useState('');
+  const [customerName, setCustomerName] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const amountNum = parseFloat(amount);
+  const isAmountValid = !isNaN(amountNum) && amountNum > 0;
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!isAmountValid || isSubmitting) return;
+
+      setIsSubmitting(true);
+      setError(null);
+
+      try {
+        const ts = Date.now();
+        const body: Record<string, unknown> = {
+          invoiceNumber: `POS-${ts}`,
+          clientName: customerName.trim() || 'Walk-in Customer',
+          clientEmail: `pos-${ts}@noreply.local`,
+          amount: amountNum,
+          asset_code: asset,
+        };
+
+        if (asset === 'USDC') {
+          body.asset_issuer = USDC_ISSUER;
+        }
+
+        if (memo.trim()) {
+          body.description = memo.trim();
+        }
+
+        const response = await apiClient.post<Invoice>('/invoices', body);
+        onSuccess(response.data);
+      } catch (err) {
+        setError(extractApiErrorMessage(err));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [isAmountValid, isSubmitting, amountNum, asset, customerName, memo, onSuccess],
+  );
+
+  return (
+    <div className="overflow-hidden rounded-lg bg-white shadow">
+      <div className="px-6 py-8 sm:px-8">
+        <h1 className="text-2xl font-bold text-gray-900">Point of Sale</h1>
+        <p className="mt-1 text-sm text-gray-500">Create a quick payment request</p>
+
+        <form onSubmit={handleSubmit} className="mt-8 space-y-6" noValidate>
+          {/* Amount */}
+          <div>
+            <label htmlFor="pos-amount" className="block text-sm font-medium text-gray-700">
+              Amount <span className="text-red-500">*</span>
+            </label>
+            <div className="mt-1">
+              <input
+                id="pos-amount"
+                type="number"
+                inputMode="decimal"
+                min="0.0000001"
+                step="any"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="0.00"
+                required
+                aria-invalid={!isAmountValid && amount.length > 0}
+                aria-describedby={!isAmountValid && amount.length > 0 ? 'amount-error' : undefined}
+                className="block w-full rounded-md border-0 py-3 px-4 text-2xl font-bold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-600"
+              />
+              {!isAmountValid && amount.length > 0 && (
+                <p id="amount-error" className="mt-1 text-sm text-red-600" role="alert">
+                  Amount must be greater than 0
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Asset Toggle */}
+          <div>
+            <span className="block text-sm font-medium text-gray-700">Asset</span>
+            <div className="mt-1 flex rounded-md shadow-sm" role="group" aria-label="Select payment asset">
+              <button
+                type="button"
+                onClick={() => setAsset('XLM')}
+                aria-pressed={asset === 'XLM'}
+                className={`flex-1 rounded-l-md border px-4 py-3 text-sm font-semibold transition-colors ${
+                  asset === 'XLM'
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                XLM (Native)
+              </button>
+              <button
+                type="button"
+                onClick={() => setAsset('USDC')}
+                aria-pressed={asset === 'USDC'}
+                className={`flex-1 rounded-r-md border-t border-b border-r px-4 py-3 text-sm font-semibold transition-colors ${
+                  asset === 'USDC'
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                USDC
+              </button>
+            </div>
+          </div>
+
+          {/* Memo / Note */}
+          <div>
+            <label htmlFor="pos-memo" className="block text-sm font-medium text-gray-700">
+              Note{' '}
+              <span className="font-normal text-gray-400">(optional)</span>
+            </label>
+            <div className="mt-1">
+              <input
+                id="pos-memo"
+                type="text"
+                value={memo}
+                onChange={(e) => setMemo(e.target.value)}
+                placeholder="e.g. Table 5, Order #42"
+                maxLength={200}
+                className="block w-full rounded-md border-0 py-2 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600"
+              />
+            </div>
+          </div>
+
+          {/* Customer Name */}
+          <div>
+            <label htmlFor="pos-customer" className="block text-sm font-medium text-gray-700">
+              Customer Name{' '}
+              <span className="font-normal text-gray-400">(optional)</span>
+            </label>
+            <div className="mt-1">
+              <input
+                id="pos-customer"
+                type="text"
+                value={customerName}
+                onChange={(e) => setCustomerName(e.target.value)}
+                placeholder="Walk-in Customer"
+                className="block w-full rounded-md border-0 py-2 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600"
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-red-50 p-4" role="alert" aria-live="assertive">
+              <p className="text-sm font-medium text-red-900">{error}</p>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={!isAmountValid || isSubmitting}
+            aria-label="Generate payment QR code"
+            className="w-full rounded-md bg-blue-600 px-4 py-4 text-center text-lg font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400 transition-colors"
+          >
+            {isSubmitting ? 'Generating...' : 'Generate QR Code'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function PaymentView({
+  invoice,
+  onNewSale,
+}: {
+  invoice: Invoice;
+  onNewSale: () => void;
+}) {
+  const router = useRouter();
+
+  const paymentUri = generatePaymentUri({
+    destination: invoice.destination_address,
+    amount: invoice.amount.toString(),
+    assetCode: invoice.asset,
+    assetIssuer: invoice.asset_issuer,
+    memo: invoice.memo,
+    memoType: 'id',
+  });
+
+  return (
+    <div className="overflow-hidden rounded-lg bg-white shadow">
+      <div className="px-6 py-8 sm:px-8">
+        <div className="text-center">
+          <p className="text-sm font-medium uppercase tracking-wide text-green-600">
+            Payment Request Ready
+          </p>
+          <p className="mt-2 text-4xl font-bold text-gray-900">
+            {invoice.amount.toLocaleString('en-US', {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 7,
+            })}{' '}
+            <span className="text-xl text-gray-600">{invoice.asset}</span>
+          </p>
+          {invoice.memo && (
+            <p className="mt-1 text-sm text-gray-500">
+              Memo: <span className="font-mono">{invoice.memo}</span>
+            </p>
+          )}
+        </div>
+
+        {/* QR Code */}
+        <div className="mt-8 flex justify-center">
+          <div className="rounded-xl border-4 border-gray-900 bg-white p-3">
+            <QRCodeSVG
+              value={paymentUri}
+              size={240}
+              level="M"
+              aria-label={`QR code for Stellar payment of ${invoice.amount} ${invoice.asset}`}
+            />
+          </div>
+        </div>
+
+        <p className="mt-4 text-center text-sm text-gray-500">
+          Scan with a Stellar wallet app to pay
+        </p>
+
+        {/* Payment URI (collapsed for power users) */}
+        <details className="mt-4">
+          <summary className="cursor-pointer text-center text-xs text-gray-400 hover:text-gray-600">
+            Show payment URI
+          </summary>
+          <p className="mt-2 break-all rounded bg-gray-50 p-2 font-mono text-xs text-gray-600">
+            {paymentUri}
+          </p>
+        </details>
+
+        <div className="mt-8 flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={onNewSale}
+            className="w-full rounded-md bg-blue-600 px-4 py-3 text-center font-semibold text-white hover:bg-blue-700 transition-colors"
+          >
+            New Sale
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push(`/invoices/${invoice.id}`)}
+            className="w-full rounded-md border border-gray-300 px-4 py-3 text-center font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            View Invoice
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function POSPage() {
+  const router = useRouter();
+  const [invoice, setInvoice] = useState<Invoice | null>(null);
+
+  const handleSuccess = useCallback((created: Invoice) => {
+    setInvoice(created);
+  }, []);
+
+  const handleNewSale = useCallback(() => {
+    setInvoice(null);
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-md">
+        {/* Nav */}
+        <button
+          type="button"
+          onClick={() => router.push('/invoices')}
+          className="mb-8 text-sm font-medium text-blue-600 hover:text-blue-700"
+        >
+          ← Back to Invoices
+        </button>
+
+        {invoice ? (
+          <PaymentView invoice={invoice} onNewSale={handleNewSale} />
+        ) : (
+          <FormView onSuccess={handleSuccess} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.90.21",
         "axios": "^1.13.6",
         "next": "16.1.6",
+        "qrcode.react": "^4.2.0",
         "react": "19.2.3",
         "react-dom": "19.2.3"
       },
@@ -69,7 +70,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1590,7 +1590,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1650,7 +1649,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2176,7 +2174,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2537,7 +2534,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3120,7 +3116,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3306,7 +3301,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5533,6 +5527,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5559,7 +5562,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5569,7 +5571,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6258,7 +6259,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6421,7 +6421,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6697,7 +6696,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.6",
     "next": "16.1.6",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },


### PR DESCRIPTION
## Summary

Implements the Point of Sale (POS) screen for face-to-face merchant transactions. Merchants can now quickly generate a payment request on the fly without filling out a full invoice form.

## What changed

### New route: `/pos`
- **Form view** — collects the minimum required fields for a POS sale:
  - Amount (numeric, required, validated `> 0` with inline error)
  - Asset toggle — XLM (Native) or USDC (auto-attaches the correct issuer public key)
  - Note / Memo — optional, stored as `description` on the invoice for internal tracking
  - Customer Name — optional, defaults to `"Walk-in Customer"` if left blank
- **Payment Request view** — shown immediately after the backend confirms the invoice:
  - Displays amount + asset prominently
  - Renders a scannable QR code encoding a SEP-0007 `web+stellar:pay?...` URI (destination, amount, asset, memo, memo_type=id)
  - "Show payment URI" expander for power users / manual copy
  - **New Sale** button — resets the form for the next transaction
  - **View Invoice** button — navigates to the full invoice detail page

### Invoices list page (`/invoices`)
- Added a **"+ Quick Sale"** button in the header toolbar that links to `/pos`

### Dependencies
- Added `qrcode.react` v4 — SVG-based QR code rendering, no canvas required, accessible via `aria-label`

## How it works

On submit the form `POST`s to `/invoices` with:
```json
{
  "invoiceNumber": "POS-<timestamp>",
  "clientName": "<entered name or 'Walk-in Customer'>",
  "clientEmail": "pos-<timestamp>@noreply.local",
  "amount": 25.5,
  "asset_code": "XLM",
  "description": "<optional note>"
}
```
No backend changes were needed — the existing endpoint and DTO handle all fields. The USDC issuer defaults to the Stellar mainnet issuer (`GA5ZS...`) and is overridable via `NEXT_PUBLIC_USDC_ISSUER` for testnet deployments.

## Test plan

- [ ] Backend running (`npm run start:dev` in `/backend`)
- [ ] Connect Freighter wallet on `/invoices` (auth required for `POST /invoices`)
- [ ] Click **"+ Quick Sale"** on the invoices page → lands on `/pos`
- [ ] Submit with no amount → button is disabled (cannot submit)
- [ ] Enter `0` → inline red error "Amount must be greater than 0"
- [ ] Toggle USDC → button highlights, XLM deselects
- [ ] Fill a valid amount, optional note, submit → transitions to payment view with QR code
- [ ] Expand "Show payment URI" → verify `web+stellar:pay?destination=...` format
- [ ] Scan QR with a Stellar wallet (Freighter / Lobstr) → payment details pre-filled
- [ ] Click **New Sale** → form resets, ready for next customer
- [ ] Click **View Invoice** → navigates to `/invoices/<id>`

closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)