### PR TITLE
feat: deploy manifests and wallet session route protection

### DIFF
--- a/soroban/README.md
+++ b/soroban/README.md
@@ -250,6 +250,45 @@ Deploys the contract to Stellar testnet and initializes it.
 4. Initializes the contract with the admin address
 5. Saves `CONTRACT_ID` to `contracts/invoice-payment/.contract-id`
 
+### Deploy Manifests
+
+Network configuration is stored in `manifests/` as TOML files. `deploy.sh`
+reads the correct manifest automatically based on `STELLAR_NETWORK`.
+
+| File | Purpose |
+|------|---------|
+| `manifests/testnet.toml` | Testnet (default) — Friendbot-funded, SDF RPC |
+| `manifests/mainnet.toml` | Mainnet — pre-funded admin required |
+
+Each manifest covers:
+
+- **`[network]`** — passphrase, RPC URL, Horizon URL
+- **`[identity]`** — local keys identity name and the env var that holds the secret key
+- **`[contract]`** — WASM path and where to write the deployed contract ID
+- **`[assets]`** — allowlist of accepted payment assets (`CODE:ISSUER` or `"native"`)
+
+Secrets are never stored in the manifest — they are referenced by env var name only.
+
+**Testnet (default):**
+```bash
+./build.sh
+./deploy.sh
+# or explicitly:
+STELLAR_NETWORK=testnet ./deploy.sh
+```
+
+**Mainnet:**
+```bash
+./build.sh
+STELLAR_NETWORK=mainnet INVOISIO_ADMIN_SECRET=S... ./deploy.sh
+```
+
+**Adding a new environment** (e.g. futurenet): copy `manifests/testnet.toml`,
+rename it `manifests/futurenet.toml`, update the `[network]` block, and run:
+```bash
+STELLAR_NETWORK=futurenet ./deploy.sh
+```
+
 ### `./invoke-record-payment.sh`
 
 Records an invoice payment on-chain.

--- a/soroban/deploy.sh
+++ b/soroban/deploy.sh
@@ -1,29 +1,65 @@
 #!/usr/bin/env bash
 #
-# Deploy the Invoisio invoice-payment contract to Stellar testnet
+# Deploy the Invoisio invoice-payment contract to Stellar
 #
-# Usage: ./deploy.sh
+# Usage:
+#   ./deploy.sh                          # deploys to testnet (default)
+#   STELLAR_NETWORK=mainnet ./deploy.sh  # deploys to mainnet
 #
 # Environment variables:
-#   STELLAR_NETWORK   - Network to deploy to (default: testnet)
-#   STELLAR_IDENTITY  - Identity name to use (default: invoisio-admin)
+#   STELLAR_NETWORK        - Network to deploy to (default: testnet)
+#   STELLAR_IDENTITY       - Override identity name from manifest
+#   INVOISIO_ADMIN_SECRET  - Admin secret key (optional; falls back to local keys identity)
+#
+# Manifest files (read automatically based on STELLAR_NETWORK):
+#   manifests/testnet.toml
+#   manifests/mainnet.toml
 #
 # The script will:
-#   1. Create/verify the identity exists
-#   2. Fund the account from Friendbot (testnet only)
-#   3. Deploy the contract WASM
-#   4. Initialize the contract with the admin address
-#   5. Save the CONTRACT_ID to contracts/invoice-payment/.contract-id
+#   1. Load the network manifest for the target environment
+#   2. Create/verify the identity exists
+#   3. Fund the account from Friendbot (testnet only)
+#   4. Deploy the contract WASM
+#   5. Initialize the contract with the admin address
+#   6. Save the CONTRACT_ID to the path defined in the manifest
 
 set -e
 
 cd "$(dirname "$0")"
 
-# Configuration
+# ── Load manifest ────────────────────────────────────────────────────────────
+
 NETWORK="${STELLAR_NETWORK:-testnet}"
-IDENTITY="${STELLAR_IDENTITY:-invoisio-admin}"
-WASM_PATH="target/wasm32v1-none/release/invoice_payment.wasm"
-CONTRACT_ID_FILE="contracts/invoice-payment/.contract-id"
+MANIFEST_FILE="manifests/${NETWORK}.toml"
+
+if [ ! -f "$MANIFEST_FILE" ]; then
+    echo "❌ Error: No manifest found for network '${NETWORK}'"
+    echo "   Expected: ${MANIFEST_FILE}"
+    echo "   Available manifests: $(ls manifests/*.toml 2>/dev/null | xargs -n1 basename | tr '\n' ' ')"
+    exit 1
+fi
+
+echo "📋 Loading manifest: ${MANIFEST_FILE}"
+
+# Parse TOML values with grep (no external deps required)
+_toml_get() {
+    grep -E "^${1}\s*=" "$MANIFEST_FILE" | head -1 | sed 's/^[^=]*=\s*//' | tr -d '"' | tr -d "'"
+}
+
+MANIFEST_IDENTITY="$(_toml_get identity.name 2>/dev/null || true)"
+MANIFEST_WASM_PATH="$(_toml_get wasm_path 2>/dev/null || true)"
+MANIFEST_CONTRACT_ID_FILE="$(_toml_get contract_id_file 2>/dev/null || true)"
+MANIFEST_SECRET_KEY_ENV="$(_toml_get secret_key_env 2>/dev/null || true)"
+
+# Resolve configuration (env overrides manifest)
+IDENTITY="${STELLAR_IDENTITY:-${MANIFEST_IDENTITY:-invoisio-admin}}"
+WASM_PATH="${MANIFEST_WASM_PATH:-target/wasm32v1-none/release/invoice_payment.wasm}"
+CONTRACT_ID_FILE="${MANIFEST_CONTRACT_ID_FILE:-contracts/invoice-payment/.contract-id}"
+
+# If a secret key env var is configured in the manifest, try to use it
+if [ -n "$MANIFEST_SECRET_KEY_ENV" ]; then
+    ADMIN_SECRET="${!MANIFEST_SECRET_KEY_ENV:-}"
+fi
 
 echo "========================================="
 echo "Deploying Invoisio Contract"

--- a/soroban/manifests/mainnet.toml
+++ b/soroban/manifests/mainnet.toml
@@ -1,0 +1,45 @@
+# Invoisio — Mainnet deployment manifest
+#
+# All secret values (keys, seeds) must be supplied via environment variables.
+# Never commit real private keys or secret seeds to this file.
+#
+# Usage:
+#   STELLAR_NETWORK=mainnet INVOISIO_ADMIN_SECRET=S... ./deploy.sh
+#
+# Required environment variables (set before running deploy.sh):
+#   INVOISIO_ADMIN_SECRET   — secret key for the admin identity (required on mainnet;
+#                             no Friendbot funding is available)
+
+[network]
+name        = "mainnet"
+passphrase  = "Public Global Stellar Network ; September 2015"
+rpc_url     = "https://mainnet.sorobanrpc.com"
+horizon_url = "https://horizon.stellar.org"
+# No friendbot on mainnet — admin account must be pre-funded.
+
+[identity]
+# Name of the local stellar keys identity to use.
+# Create with: stellar keys generate --global invoisio-admin-mainnet
+name = "invoisio-admin-mainnet"
+# Secret key injected from env at deploy time.
+secret_key_env = "INVOISIO_ADMIN_SECRET"
+
+[contract]
+wasm_path        = "target/wasm32v1-none/release/invoice_payment.wasm"
+contract_id_file = "contracts/invoice-payment/.contract-id-mainnet"
+
+[assets]
+# Allowlist of accepted payment assets on mainnet.
+# Format: CODE:ISSUER  (use "native" for XLM)
+# USDC on mainnet issued by Centre.
+allowlist = [
+  "native",
+  "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+]
+
+# Mainnet deployment checklist:
+#   1. Build the WASM:         ./build.sh
+#   2. Verify the WASM hash before deploying (check with the team).
+#   3. Ensure the admin account has enough XLM for fees + rent.
+#   4. Run:  STELLAR_NETWORK=mainnet INVOISIO_ADMIN_SECRET=S... ./deploy.sh
+#   5. Commit the resulting .contract-id-mainnet file to git.

--- a/soroban/manifests/testnet.toml
+++ b/soroban/manifests/testnet.toml
@@ -1,0 +1,49 @@
+# Invoisio — Testnet deployment manifest
+#
+# All secret values (keys, seeds) must be supplied via environment variables.
+# Never commit real private keys or secret seeds to this file.
+#
+# Usage:
+#   source manifests/testnet.toml  (not directly; read by deploy.sh)
+#   STELLAR_NETWORK=testnet ./deploy.sh
+#
+# Required environment variables (set before running deploy.sh):
+#   INVOISIO_ADMIN_SECRET   — secret key for the admin identity (for CI/CD)
+#                             Leave unset to use an existing stellar keys identity.
+
+[network]
+name            = "testnet"
+passphrase      = "Test SDF Network ; September 2015"
+rpc_url         = "https://soroban-testnet.stellar.org"
+horizon_url     = "https://horizon-testnet.stellar.org"
+friendbot_url   = "https://friendbot.stellar.org"
+
+[identity]
+# Name of the local stellar keys identity to use.
+# Create with: stellar keys generate --global invoisio-admin --network testnet
+name = "invoisio-admin"
+# Secret key injected from env at deploy time (optional; identity name used if absent).
+secret_key_env = "INVOISIO_ADMIN_SECRET"
+
+[contract]
+# Path to the compiled WASM relative to the soroban/ directory.
+wasm_path       = "target/wasm32v1-none/release/invoice_payment.wasm"
+# File where the deployed contract ID is written after a successful deploy.
+contract_id_file = "contracts/invoice-payment/.contract-id"
+
+[assets]
+# Allowlist of accepted payment assets.
+# Format: CODE:ISSUER  (use "native" for XLM)
+# Testnet USDC issued by the SDF test anchor.
+allowlist = [
+  "native",
+  "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+]
+
+# Example overrides for local development:
+#
+# [network]
+# rpc_url = "http://localhost:8000/soroban/rpc"
+#
+# To deploy:
+#   INVOISIO_ADMIN_SECRET=S... STELLAR_NETWORK=testnet ./deploy.sh

--- a/web/app/invoices/[id]/page.tsx
+++ b/web/app/invoices/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useState, useCallback } from 'react';
 import { generatePaymentUri, openPaymentWallet, getWalletInfo } from '@/lib/sep0007';
 import { usePollInvoiceStatus } from '@/hooks/use-poll-invoice-status';
 import { apiClient } from '@/lib/api-client';
+import { RequireAuth } from '@/components/require-auth';
 
 interface Invoice {
   id: string;
@@ -31,7 +32,7 @@ interface WalletInfo {
   message: string;
 }
 
-export default function InvoiceDetailPage() {
+function InvoiceDetailContent() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
   const invoiceId = params?.id as string;
@@ -391,5 +392,13 @@ export default function InvoiceDetailPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function InvoiceDetailPage() {
+  return (
+    <RequireAuth>
+      <InvoiceDetailContent />
+    </RequireAuth>
   );
 }

--- a/web/app/invoices/page.tsx
+++ b/web/app/invoices/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api-client';
 import { WalletAuthControls } from '@/components/wallet-auth-controls';
+import { RequireAuth } from '@/components/require-auth';
 
 interface Invoice {
   id: string;
@@ -65,7 +66,7 @@ async function fetchInvoicesPage(page: number, pageSize: number): Promise<Invoic
     : { items, page, pageSize, hasMore };
 }
 
-export default function InvoicesPage() {
+function InvoicesContent() {
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<'all' | 'pending' | 'paid' | 'overdue' | 'cancelled'>('all');
   const pageSize = 20;
@@ -348,5 +349,13 @@ export default function InvoicesPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function InvoicesPage() {
+  return (
+    <RequireAuth>
+      <InvoicesContent />
+    </RequireAuth>
   );
 }

--- a/web/app/pos/page.tsx
+++ b/web/app/pos/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { QRCodeSVG } from 'qrcode.react';
 import { apiClient, extractApiErrorMessage } from '@/lib/api-client';
 import { generatePaymentUri } from '@/lib/sep0007';
+import { RequireAuth } from '@/components/require-auth';
 
 // Stellar mainnet USDC issuer — override via NEXT_PUBLIC_USDC_ISSUER for testnet
 const USDC_ISSUER =
@@ -286,7 +287,7 @@ function PaymentView({
   );
 }
 
-export default function POSPage() {
+function POSContent() {
   const router = useRouter();
   const [invoice, setInvoice] = useState<Invoice | null>(null);
 
@@ -317,5 +318,13 @@ export default function POSPage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function POSPage() {
+  return (
+    <RequireAuth>
+      <POSContent />
+    </RequireAuth>
   );
 }

--- a/web/components/require-auth.tsx
+++ b/web/components/require-auth.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useWalletAuth } from '@/hooks/use-wallet-auth';
+
+interface RequireAuthProps {
+  children: React.ReactNode;
+  redirectTo?: string;
+}
+
+export function RequireAuth({ children, redirectTo = '/login' }: RequireAuthProps) {
+  const { isAuthenticated, isLoading } = useWalletAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(redirectTo);
+    }
+  }, [isAuthenticated, isLoading, redirectTo, router]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
Closes #141 
— Deploy manifests for testnet and mainnet readiness:
- Add soroban/manifests/testnet.toml and mainnet.toml with network passphrase, RPC URL, Horizon URL, identity config, WASM path, contract ID file path, and asset allowlist
- Secrets referenced by env var name only — never stored in manifests
- Update deploy.sh to auto-load the manifest for the active network, falling back gracefully if no env secret is configured
- Document manifest format, usage, and how to add new environments in soroban/README.md

Closes #153 
— Wallet session persistence and route protection:
- Session persistence was already implemented in use-wallet-auth.tsx (localStorage with token validation on mount)
- Add web/components/require-auth.tsx: shows a spinner while auth state resolves, redirects unauthenticated users to /login, renders children only when signed in
- Wrap /invoices, /invoices/[id], and /pos pages with RequireAuth