### PR TITLE
feat(tooling): add admin and allowlist operation scripts

### DIFF
--- a/soroban/invoke-allow-asset.sh
+++ b/soroban/invoke-allow-asset.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Add an asset to the allowlist on the Invoisio Soroban contract
+#
+# Usage: ./invoke-allow-asset.sh <asset_code> <asset_issuer>
+#
+# Arguments:
+#   asset_code    - Asset code (e.g., 'USDC', 'EURT')
+#   asset_issuer  - Stellar account address of the issuer (G...)
+#
+# Environment variables:
+#   STELLAR_NETWORK   - Network to use (default: testnet)
+#   STELLAR_IDENTITY  - Identity to sign with (default: invoisio-admin)
+#   CONTRACT_ID       - Override contract ID (default: read from .contract-id file)
+#
+
+set -e
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+validate_stellar_address() {
+    if ! [[ $1 =~ ^G[A-Z2-7]{55}$ ]]; then
+        return 1
+    fi
+    return 0
+}
+
+NETWORK="${STELLAR_NETWORK:-testnet}"
+IDENTITY="${STELLAR_IDENTITY:-invoisio-admin}"
+CONTRACT_ID_FILE="contracts/invoice-payment/.contract-id"
+
+ASSET_CODE="$1"
+ASSET_ISSUER="$2"
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <asset_code> <asset_issuer>"
+    echo ""
+    echo "Arguments:"
+    echo "  asset_code    - Asset code (e.g., 'USDC')"
+    echo "  asset_issuer  - Stellar account address of the issuer (G...)"
+    exit 1
+fi
+
+if [ -z "$ASSET_CODE" ]; then
+    echo "❌ Error: asset_code cannot be empty"
+    exit 1
+fi
+
+if ! validate_stellar_address "$ASSET_ISSUER"; then
+    echo "❌ Error: Invalid Stellar address format for asset_issuer: $ASSET_ISSUER"
+    echo "   Expected format: G followed by 55 base-32 characters"
+    exit 1
+fi
+
+if [ -n "$CONTRACT_ID" ]; then
+    echo "ℹ️  Using CONTRACT_ID from environment: $CONTRACT_ID"
+elif [ -f "$CONTRACT_ID_FILE" ]; then
+    CONTRACT_ID=$(cat "$CONTRACT_ID_FILE")
+else
+    echo "❌ Error: Contract ID not found"
+    echo ""
+    echo "Either:"
+    echo "  1. Deploy the contract first: ./deploy.sh"
+    echo "  2. Set CONTRACT_ID environment variable"
+    exit 1
+fi
+
+echo "========================================="
+echo "Allowlisting Asset"
+echo "========================================="
+echo "Contract ID:    $CONTRACT_ID"
+echo "Asset Code:     $ASSET_CODE"
+echo "Asset Issuer:   $ASSET_ISSUER"
+echo "Network:        $NETWORK"
+echo "Identity:       $IDENTITY"
+echo ""
+echo "🚀 Invoking allow_asset..."
+echo ""
+
+stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$IDENTITY" \
+    --network "$NETWORK" \
+    --send yes \
+    -- allow_asset \
+    --code "$ASSET_CODE" \
+    --issuer "$ASSET_ISSUER"
+
+echo ""
+echo "✅ Asset allowlisted successfully!"
+echo ""

--- a/soroban/invoke-revoke-asset.sh
+++ b/soroban/invoke-revoke-asset.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Remove an asset from the allowlist on the Invoisio Soroban contract
+#
+# Usage: ./invoke-revoke-asset.sh <asset_code> <asset_issuer>
+#
+# Arguments:
+#   asset_code    - Asset code (e.g., 'USDC', 'EURT')
+#   asset_issuer  - Stellar account address of the issuer (G...)
+#
+# Environment variables:
+#   STELLAR_NETWORK   - Network to use (default: testnet)
+#   STELLAR_IDENTITY  - Identity to sign with (default: invoisio-admin)
+#   CONTRACT_ID       - Override contract ID (default: read from .contract-id file)
+#
+
+set -e
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+validate_stellar_address() {
+    if ! [[ $1 =~ ^G[A-Z2-7]{55}$ ]]; then
+        return 1
+    fi
+    return 0
+}
+
+NETWORK="${STELLAR_NETWORK:-testnet}"
+IDENTITY="${STELLAR_IDENTITY:-invoisio-admin}"
+CONTRACT_ID_FILE="contracts/invoice-payment/.contract-id"
+
+ASSET_CODE="$1"
+ASSET_ISSUER="$2"
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <asset_code> <asset_issuer>"
+    echo ""
+    echo "Arguments:"
+    echo "  asset_code    - Asset code (e.g., 'USDC')"
+    echo "  asset_issuer  - Stellar account address of the issuer (G...)"
+    exit 1
+fi
+
+if [ -z "$ASSET_CODE" ]; then
+    echo "❌ Error: asset_code cannot be empty"
+    exit 1
+fi
+
+if ! validate_stellar_address "$ASSET_ISSUER"; then
+    echo "❌ Error: Invalid Stellar address format for asset_issuer: $ASSET_ISSUER"
+    echo "   Expected format: G followed by 55 base-32 characters"
+    exit 1
+fi
+
+if [ -n "$CONTRACT_ID" ]; then
+    echo "ℹ️  Using CONTRACT_ID from environment: $CONTRACT_ID"
+elif [ -f "$CONTRACT_ID_FILE" ]; then
+    CONTRACT_ID=$(cat "$CONTRACT_ID_FILE")
+else
+    echo "❌ Error: Contract ID not found"
+    echo ""
+    echo "Either:"
+    echo "  1. Deploy the contract first: ./deploy.sh"
+    echo "  2. Set CONTRACT_ID environment variable"
+    exit 1
+fi
+
+echo "========================================="
+echo "Revoking Asset"
+echo "========================================="
+echo "Contract ID:    $CONTRACT_ID"
+echo "Asset Code:     $ASSET_CODE"
+echo "Asset Issuer:   $ASSET_ISSUER"
+echo "Network:        $NETWORK"
+echo "Identity:       $IDENTITY"
+echo ""
+echo "🚀 Invoking revoke_asset..."
+echo ""
+
+stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$IDENTITY" \
+    --network "$NETWORK" \
+    --send yes \
+    -- revoke_asset \
+    --code "$ASSET_CODE" \
+    --issuer "$ASSET_ISSUER"
+
+echo ""
+echo "✅ Asset revoked successfully!"
+echo ""

--- a/soroban/invoke-set-admin.sh
+++ b/soroban/invoke-set-admin.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Transfer admin rights to a new admin on the Invoisio Soroban contract
+#
+# Usage: ./invoke-set-admin.sh <new_admin>
+#
+# Arguments:
+#   new_admin     - Stellar account address for the new admin (G...)
+#
+# Environment variables:
+#   STELLAR_NETWORK   - Network to use (default: testnet)
+#   STELLAR_IDENTITY  - Identity to sign with (default: invoisio-admin)
+#   CONTRACT_ID       - Override contract ID (default: read from .contract-id file)
+#
+
+set -e
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+validate_stellar_address() {
+    if ! [[ $1 =~ ^G[A-Z2-7]{55}$ ]]; then
+        return 1
+    fi
+    return 0
+}
+
+NETWORK="${STELLAR_NETWORK:-testnet}"
+IDENTITY="${STELLAR_IDENTITY:-invoisio-admin}"
+CONTRACT_ID_FILE="contracts/invoice-payment/.contract-id"
+
+NEW_ADMIN="$1"
+
+if [ -z "$NEW_ADMIN" ]; then
+    echo "Usage: $0 <new_admin>"
+    echo ""
+    echo "Arguments:"
+    echo "  new_admin     - Stellar account address for the new admin (G...)"
+    exit 1
+fi
+
+if ! validate_stellar_address "$NEW_ADMIN"; then
+    echo "❌ Error: Invalid Stellar address format for new_admin: $NEW_ADMIN"
+    echo "   Expected format: G followed by 55 base-32 characters"
+    exit 1
+fi
+
+if [ -n "$CONTRACT_ID" ]; then
+    echo "ℹ️  Using CONTRACT_ID from environment: $CONTRACT_ID"
+elif [ -f "$CONTRACT_ID_FILE" ]; then
+    CONTRACT_ID=$(cat "$CONTRACT_ID_FILE")
+else
+    echo "❌ Error: Contract ID not found"
+    echo ""
+    echo "Either:"
+    echo "  1. Deploy the contract first: ./deploy.sh"
+    echo "  2. Set CONTRACT_ID environment variable"
+    exit 1
+fi
+
+echo "========================================="
+echo "Transferring Admin Rights"
+echo "========================================="
+echo "Contract ID:    $CONTRACT_ID"
+echo "New Admin:      $NEW_ADMIN"
+echo "Network:        $NETWORK"
+echo "Identity:       $IDENTITY"
+echo ""
+echo "🚀 Invoking set_admin..."
+echo ""
+
+stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$IDENTITY" \
+    --network "$NETWORK" \
+    --send yes \
+    -- set_admin \
+    --new_admin "$NEW_ADMIN"
+
+echo ""
+echo "✅ Admin transferred successfully!"
+echo ""

--- a/soroban/invoke-set-allow-native.sh
+++ b/soroban/invoke-set-allow-native.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Toggle whether native XLM payments are permitted on the Invoisio contract
+#
+# Usage: ./invoke-set-allow-native.sh <true|false>
+#
+# Arguments:
+#   allowed       - true or false
+#
+# Environment variables:
+#   STELLAR_NETWORK   - Network to use (default: testnet)
+#   STELLAR_IDENTITY  - Identity to sign with (default: invoisio-admin)
+#   CONTRACT_ID       - Override contract ID (default: read from .contract-id file)
+#
+
+set -e
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+NETWORK="${STELLAR_NETWORK:-testnet}"
+IDENTITY="${STELLAR_IDENTITY:-invoisio-admin}"
+CONTRACT_ID_FILE="contracts/invoice-payment/.contract-id"
+
+ALLOWED="$1"
+
+if [ -z "$ALLOWED" ]; then
+    echo "Usage: $0 <true|false>"
+    echo ""
+    echo "Arguments:"
+    echo "  allowed       - true or false"
+    exit 1
+fi
+
+if [ "$ALLOWED" != "true" ] && [ "$ALLOWED" != "false" ]; then
+    echo "❌ Error: Argument must be exactly 'true' or 'false'"
+    exit 1
+fi
+
+if [ -n "$CONTRACT_ID" ]; then
+    echo "ℹ️  Using CONTRACT_ID from environment: $CONTRACT_ID"
+elif [ -f "$CONTRACT_ID_FILE" ]; then
+    CONTRACT_ID=$(cat "$CONTRACT_ID_FILE")
+else
+    echo "❌ Error: Contract ID not found"
+    echo ""
+    echo "Either:"
+    echo "  1. Deploy the contract first: ./deploy.sh"
+    echo "  2. Set CONTRACT_ID environment variable"
+    exit 1
+fi
+
+echo "========================================="
+echo "Setting Allow Native"
+echo "========================================="
+echo "Contract ID:    $CONTRACT_ID"
+echo "Allowed:        $ALLOWED"
+echo "Network:        $NETWORK"
+echo "Identity:       $IDENTITY"
+echo ""
+echo "🚀 Invoking set_allow_native..."
+echo ""
+
+stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$IDENTITY" \
+    --network "$NETWORK" \
+    --send yes \
+    -- set_allow_native \
+    --allowed "$ALLOWED"
+
+echo ""
+echo "✅ Native allowlist status updated successfully!"
+echo ""


### PR DESCRIPTION
Closes #142

Adds four repeatable Bash scripts for common admin tasks on the Invoisio Soroban contract, so contributors and operators do not need to hand-craft CLI commands.

Scripts added:
- invoke-set-admin.sh       – transfer admin rights to a new address
- invoke-allow-asset.sh     – add a (code, issuer) pair to the allowlist
- invoke-revoke-asset.sh    – remove an asset from the allowlist
- invoke-set-allow-native.sh – toggle native XLM payment acceptance

All scripts:
- Document required env vars inline (STELLAR_NETWORK, STELLAR_IDENTITY, CONTRACT_ID)
- Surface clear errors when inputs are missing or invalid
- Read CONTRACT_ID from .contract-id file if not set in environment
- Follow the style of existing invoke-*.sh scripts