### PR TITLE
feat(mobile): persist merchant session across restarts with safe expiry handling

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -3,6 +3,7 @@ import { StatusBar } from "expo-status-bar";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { View, ActivityIndicator } from "react-native";
 import { useEffect, useState } from "react";
+import axios from "axios";
 import {
   useFonts,
   SpaceGrotesk_400Regular,
@@ -46,6 +47,31 @@ export default function RootLayout() {
     };
     void initAuth();
   }, [loadAuth]);
+
+  // Handle mid-session expiry: if any authenticated request is rejected because
+  // the token is no longer valid, clear the session. AuthGuard then redirects
+  // the merchant back to login.
+  useEffect(() => {
+    const interceptorId = axios.interceptors.response.use(
+      (response) => response,
+      (error: unknown) => {
+        if (axios.isAxiosError(error) && error.response) {
+          const status = error.response.status;
+          if (status === 401 || status === 403) {
+            const { isAuthenticated, clearAuth } = useAuthStore.getState();
+            if (isAuthenticated) {
+              void clearAuth();
+            }
+          }
+        }
+        throw error;
+      },
+    );
+
+    return () => {
+      axios.interceptors.response.eject(interceptorId);
+    };
+  }, []);
 
   if (!fontsLoaded) {
     return (

--- a/mobile/hooks/use-auth-store.ts
+++ b/mobile/hooks/use-auth-store.ts
@@ -7,6 +7,7 @@ const AUTH_STORAGE_KEY = "@invoisio:auth";
 interface AuthState {
   accessToken: string | null;
   publicKey: string | null;
+  expiresAt: number | null;
   isAuthenticated: boolean;
   isLoading: boolean;
 
@@ -19,12 +20,14 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: null,
   publicKey: null,
+  expiresAt: null,
   isAuthenticated: false,
   isLoading: true,
 
   setAuth: async (accessToken: string, publicKey: string) => {
     try {
-      const authData = { accessToken, publicKey };
+      const expiresAt = AuthService.decodeTokenExpiry(accessToken);
+      const authData = { accessToken, publicKey, expiresAt };
       await SecureStore.setItemAsync(
         AUTH_STORAGE_KEY,
         JSON.stringify(authData),
@@ -32,6 +35,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       set({
         accessToken,
         publicKey,
+        expiresAt,
         isAuthenticated: true,
         isLoading: false,
       });
@@ -47,6 +51,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       set({
         accessToken: null,
         publicKey: null,
+        expiresAt: null,
         isAuthenticated: false,
         isLoading: false,
       });
@@ -68,13 +73,26 @@ export const useAuthStore = create<AuthState>((set) => ({
       const authData = JSON.parse(authDataString) as {
         accessToken?: string;
         publicKey?: string;
+        expiresAt?: number | null;
       };
 
       if (authData.accessToken && authData.publicKey) {
-        const isValid = await AuthService.verifyToken(authData.accessToken);
+        const expiresAt =
+          typeof authData.expiresAt === "number" ? authData.expiresAt : null;
 
-        if (!isValid) {
-          // Token expired — clear stored credentials and return to login
+        // Local expiry check first — works offline and avoids a wasted request.
+        if (expiresAt != null && Date.now() >= expiresAt) {
+          await SecureStore.deleteItemAsync(AUTH_STORAGE_KEY);
+          set({ isLoading: false });
+          return false;
+        }
+
+        // Confirm with the backend. A network failure ("unknown") keeps the
+        // restored session so transient connectivity issues do not log the
+        // merchant out; only an explicit rejection clears credentials.
+        const status = await AuthService.verifyToken(authData.accessToken);
+
+        if (status === "invalid") {
           await SecureStore.deleteItemAsync(AUTH_STORAGE_KEY);
           set({ isLoading: false });
           return false;
@@ -83,6 +101,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         set({
           accessToken: authData.accessToken,
           publicKey: authData.publicKey,
+          expiresAt,
           isAuthenticated: true,
           isLoading: false,
         });

--- a/mobile/lib/auth-service.ts
+++ b/mobile/lib/auth-service.ts
@@ -49,17 +49,26 @@ export const AuthService = {
   },
 
   /**
-   * Verify a stored access token is still valid against the backend.
-   * Returns false if expired or invalid (safe to call on app boot).
+   * Verify a stored access token against the backend.
+   * A network failure resolves to "unknown" so a flaky connection does not
+   * force a logout; only an explicit 401/403 means the token is rejected.
    */
-  async verifyToken(accessToken: string): Promise<boolean> {
+  async verifyToken(
+    accessToken: string,
+  ): Promise<"valid" | "invalid" | "unknown"> {
     try {
       await axios.get(`${API_URL}/auth/me`, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
-      return true;
-    } catch {
-      return false;
+      return "valid";
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        const status = error.response.status;
+        if (status === 401 || status === 403) {
+          return "invalid";
+        }
+      }
+      return "unknown";
     }
   },
 
@@ -69,5 +78,29 @@ export const AuthService = {
    */
   createSiweMessage(nonce: string): string {
     return `Sign this message to authenticate with Invoisio\n\nNonce: ${nonce}`;
+  },
+
+  /**
+   * Decode a JWT's `exp` claim into epoch milliseconds without verifying the
+   * signature. Used only to store session metadata so expiry can be checked
+   * locally (e.g. offline) on app boot. Returns null if the token has no
+   * readable numeric `exp`.
+   */
+  decodeTokenExpiry(accessToken: string): number | null {
+    try {
+      const payload = accessToken.split(".")[1];
+      if (!payload) {
+        return null;
+      }
+      const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+      const json = Buffer.from(normalized, "base64").toString("utf-8");
+      const claims = JSON.parse(json) as { exp?: unknown };
+      if (typeof claims.exp === "number" && Number.isFinite(claims.exp)) {
+        return claims.exp * 1000;
+      }
+      return null;
+    } catch {
+      return null;
+    }
   },
 };


### PR DESCRIPTION
## Overview
Keep merchant sessions alive across app restarts without storing sensitive data insecurely, and route users back to login cleanly when a session expires.

## Changes (mobile)
- **Session metadata in secure storage** — `setAuth` now decodes the JWT `exp` claim and persists `expiresAt` alongside the token/public key in `expo-secure-store`. No additional sensitive data is stored.
- **Restore + expiry on boot** (`loadAuth`):
  - Checks `expiresAt` locally first, so an expired session is detected even with no network and avoids a wasted request.
  - Still confirms with the backend, but now distinguishes an explicit rejection (`401/403` → clear session) from a transient network failure (keep the restored session) so flaky connectivity does not log merchants out.
- **Mid-session expiry** — a global axios response interceptor in `_layout.tsx` clears the session on a `401/403` from any authenticated request. `AuthGuard` then redirects the merchant back to `/login`.

## Acceptance criteria
- ✅ Relaunching the app restores a valid session (token + `expiresAt` rehydrated from SecureStore, validated on boot).
- ✅ Expired sessions redirect the user back to login safely (local expiry check on boot + global 401/403 interceptor during use, both via `clearAuth` → `AuthGuard`).

## Verification
- `npm run typecheck` (tsc) — passes.
- `npm run lint` — clean on all changed files (pre-existing lint errors in unrelated files were left untouched).
- Note: on-device/simulator smoke testing (per `mobile/SMOKE_TEST_CHECKLIST.md`) was not run in this environment.

closes #167