### PR TITLE
Version invoice_payment_recorded event for indexer stability

### DIFF
--- a/soroban/README.md
+++ b/soroban/README.md
@@ -507,10 +507,12 @@ Every `record_payment` call publishes a flattened event payload so off-chain ind
 
 ```
 Topics : (Symbol "invoice_payment_recorded")
-Data   : InvoicePaymentRecorded { invoice_id, payer, asset_code, asset_issuer, amount }
+Data   : InvoicePaymentRecorded { schema_version, invoice_id, payer, asset_code, asset_issuer, amount, settlement_ref }
 ```
 
 Note: The `tx_hash` is not directly inside the payload, but is automatically included by Horizon in the event envelope when fetching via RPC.
+
+The leading `schema_version` field (currently `1`, see `EVENT_SCHEMA_VERSION` in `events.rs`) lets off-chain indexers detect the event payload shape and stay forward-compatible. Consumers should read `schema_version` first and branch on it; when the payload changes in a breaking way the version is bumped (and, per the event compatibility policy above, a new event name may also be introduced).
 
 Subscribe and decode via CLI:
 ```sh

--- a/soroban/contracts/invoice-payment/src/events.rs
+++ b/soroban/contracts/invoice-payment/src/events.rs
@@ -1,8 +1,14 @@
 use soroban_sdk::{contractevent, Address, Env, String};
 
+/// Schema version for the `invoice_payment_recorded` event payload.
+/// Bumped only when the payload shape changes in a breaking way so that
+/// off-chain indexers can detect and adapt to the event format.
+pub const EVENT_SCHEMA_VERSION: u32 = 1;
+
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct InvoicePaymentRecorded {
+    pub schema_version: u32,
     pub invoice_id: String,
     pub payer: Address,
     pub asset_code: String,
@@ -37,6 +43,7 @@ pub fn emit_payment_recorded(
     settlement_ref: String,
 ) {
     let payload = InvoicePaymentRecorded {
+        schema_version: EVENT_SCHEMA_VERSION,
         invoice_id,
         payer,
         asset_code,

--- a/soroban/contracts/invoice-payment/src/test.rs
+++ b/soroban/contracts/invoice-payment/src/test.rs
@@ -495,7 +495,8 @@ fn test_first_payment_succeeds_emits_event_and_increments_count() {
                     (Symbol::new(&env, "asset_code"), code_val),
                     (Symbol::new(&env, "asset_issuer"), iss_val),
                     (Symbol::new(&env, "amount"), amt_val),
-                    (Symbol::new(&env, "settlement_ref"), ref_val)
+                    (Symbol::new(&env, "settlement_ref"), ref_val),
+                    (Symbol::new(&env, "schema_version"), 1u32.into_val(&env))
                 ]
                 .into_val(&env),
             ),
@@ -971,7 +972,8 @@ fn test_record_payment_emits_payment_recorded_event() {
                     (Symbol::new(&env, "asset_code"), code_val),
                     (Symbol::new(&env, "asset_issuer"), iss_val),
                     (Symbol::new(&env, "amount"), amt_val),
-                    (Symbol::new(&env, "settlement_ref"), ref_val)
+                    (Symbol::new(&env, "settlement_ref"), ref_val),
+                    (Symbol::new(&env, "schema_version"), 1u32.into_val(&env))
                 ]
                 .into_val(&env),
             ),
@@ -2180,7 +2182,8 @@ fn test_settlement_ref_emitted_in_event() {
                     (Symbol::new(&env, "asset_code"), code_val),
                     (Symbol::new(&env, "asset_issuer"), iss_val),
                     (Symbol::new(&env, "amount"), amt_val),
-                    (Symbol::new(&env, "settlement_ref"), ref_val)
+                    (Symbol::new(&env, "settlement_ref"), ref_val),
+                    (Symbol::new(&env, "schema_version"), 1u32.into_val(&env))
                 ]
                 .into_val(&env),
             ),


### PR DESCRIPTION
Closes #137. Adds a schema_version field (EVENT_SCHEMA_VERSION = 1) to the invoice_payment_recorded Soroban event so off-chain indexers can detect the payload shape and stay forward-compatible. Updates the event assertions and the Soroban README. Soroban map equality is key-sorted, so existing field ordering is unaffected.