### PR TITLE
Add idempotency guards and reconciliation logging for payment processing

### DIFF
--- a/backend/prisma/migrations/20260620235959_add_missing_core_tables/migration.sql
+++ b/backend/prisma/migrations/20260620235959_add_missing_core_tables/migration.sql
@@ -1,0 +1,92 @@
+-- These tables exist in schema.prisma (InvoiceStatusHistory, Payment,
+-- BackfillRun, ProcessedEvent) but were never created by a migration,
+-- which left every environment that runs `prisma migrate deploy` from
+-- scratch without these tables. Add them now, in dependency order, so
+-- later migrations (e.g. payments_tx_hash_key) have something to act on.
+--
+-- invoices.amount_paid / invoices.amount_due are likewise declared in
+-- schema.prisma and used throughout the partial-payment/reconciliation
+-- code paths, but were never added by any migration either.
+
+-- AlterTable
+ALTER TABLE "invoices" ADD COLUMN "amount_paid" DECIMAL(18,7) NOT NULL DEFAULT 0;
+ALTER TABLE "invoices" ADD COLUMN "amount_due" DECIMAL(18,7);
+UPDATE "invoices" SET "amount_due" = "amount" - "amount_paid" WHERE "amount_due" IS NULL;
+ALTER TABLE "invoices" ALTER COLUMN "amount_due" SET NOT NULL;
+
+-- CreateTable
+CREATE TABLE "invoice_status_history" (
+    "id" TEXT NOT NULL,
+    "invoice_id" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "invoice_status_history_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "invoice_status_history_invoice_id_idx" ON "invoice_status_history"("invoice_id");
+
+-- AddForeignKey
+ALTER TABLE "invoice_status_history" ADD CONSTRAINT "invoice_status_history_invoice_id_fkey" FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable
+CREATE TABLE "payments" (
+    "id" TEXT NOT NULL,
+    "invoice_id" TEXT NOT NULL,
+    "amount" DECIMAL(18,7) NOT NULL,
+    "tx_hash" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "payments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "payments_invoice_id_idx" ON "payments"("invoice_id");
+
+-- AddForeignKey
+ALTER TABLE "payments" ADD CONSTRAINT "payments_invoice_id_fkey" FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable
+CREATE TABLE "backfill_runs" (
+    "id" SERIAL NOT NULL,
+    "started_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completed_at" TIMESTAMP(3),
+    "start_ledger" BIGINT,
+    "end_ledger" BIGINT,
+    "events_processed" INTEGER NOT NULL DEFAULT 0,
+    "events_matched" INTEGER NOT NULL DEFAULT 0,
+    "events_skipped" INTEGER NOT NULL DEFAULT 0,
+    "events_failed" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'running',
+    "error_message" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "backfill_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "processed_events" (
+    "id" SERIAL NOT NULL,
+    "tx_hash" TEXT NOT NULL,
+    "ledger" BIGINT NOT NULL,
+    "invoice_id" TEXT NOT NULL,
+    "contract_id" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'success',
+    "error_message" TEXT,
+    "processed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "processed_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "processed_events_tx_hash_invoice_id_contract_id_key" ON "processed_events"("tx_hash", "invoice_id", "contract_id");
+
+-- CreateIndex
+CREATE INDEX "processed_events_ledger_idx" ON "processed_events"("ledger");
+
+-- CreateIndex
+CREATE INDEX "processed_events_invoice_id_idx" ON "processed_events"("invoice_id");
+
+-- CreateIndex
+CREATE INDEX "processed_events_status_idx" ON "processed_events"("status");

--- a/backend/prisma/migrations/20260621000000_add_payment_txhash_unique/migration.sql
+++ b/backend/prisma/migrations/20260621000000_add_payment_txhash_unique/migration.sql
@@ -1,0 +1,3 @@
+-- Prevent the same on-chain transaction from being recorded as more than
+-- one Payment row (replay/duplicate-processing guard).
+CREATE UNIQUE INDEX "payments_tx_hash_key" ON "payments"("tx_hash");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -140,7 +140,7 @@ model Payment {
   invoiceId   String   @map("invoice_id")
   invoice     Invoice  @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
   amount      Decimal  @db.Decimal(18, 7)
-  txHash      String?  @map("tx_hash")
+  txHash      String?  @unique @map("tx_hash")
   createdAt   DateTime @default(now()) @map("created_at")
 
   @@index([invoiceId])

--- a/backend/src/invoices/invoices.service.soroban.spec.ts
+++ b/backend/src/invoices/invoices.service.soroban.spec.ts
@@ -48,6 +48,47 @@ class FakePrisma {
       return { id: "fake-id", ...data, createdAt: new Date() };
     },
   };
+  payment = {
+    _store: [] as any[],
+    create: async ({ data }: any) => {
+      if (data.txHash) {
+        const dup = (FakePrisma as any).instance.payment._store.find(
+          (p: any) => p.txHash === data.txHash,
+        );
+        if (dup) {
+          const err: any = new Error("Unique constraint failed");
+          err.code = "P2002";
+          throw err;
+        }
+      }
+      const row = {
+        id: `pay-${(FakePrisma as any).instance.payment._store.length}`,
+        ...data,
+        createdAt: new Date(),
+      };
+      (FakePrisma as any).instance.payment._store.push(row);
+      return row;
+    },
+  };
+  processedEvent = {
+    _store: new Map<string, any>(),
+    findUnique: async ({ where: { txHash_invoiceId_contractId } }: any) => {
+      const key = JSON.stringify(txHash_invoiceId_contractId);
+      return (
+        (FakePrisma as any).instance.processedEvent._store.get(key) || null
+      );
+    },
+    create: async ({ data }: any) => {
+      const key = JSON.stringify({
+        txHash: data.txHash,
+        invoiceId: data.invoiceId,
+        contractId: data.contractId,
+      });
+      const row = { id: 1, processedAt: new Date(), ...data };
+      (FakePrisma as any).instance.processedEvent._store.set(key, row);
+      return row;
+    },
+  };
   static instance: any;
   constructor() {
     (FakePrisma as any).instance = this;
@@ -152,5 +193,49 @@ describe("InvoicesService.applySorobanPaymentEvent", () => {
     expect(first.status).toBe("paid");
     expect(normalized.status).toBe("paid");
     expect(normalized.tx_hash).toBe("soroban:evt-1");
+  });
+
+  it("does not double-count amountPaid when a partial-payment event is replayed", async () => {
+    const id = "7a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9";
+    await prisma.invoice.create({
+      data: {
+        id,
+        clientName: "C",
+        amount: 1000,
+        amountPaid: 0,
+        amountDue: 1000,
+        asset_code: "XLM",
+        memo: "789",
+        memo_type: "ID",
+        status: "pending",
+        tx_hash: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const event = {
+      eventId: "evt-partial-1",
+      contractId: "Cpartial",
+      invoice_id: `invoisio-${id}`,
+      amount: "300",
+    } as any;
+
+    const warnSpy = jest
+      .spyOn((service as any).logger, "warn")
+      .mockImplementation(() => {});
+
+    const first = await service.applySorobanPaymentEvent(event);
+    expect(first?.status).toBe("partially_paid");
+    expect(Number((first as any).amountPaid)).toBe(300);
+
+    const replayed = await service.applySorobanPaymentEvent(event);
+    expect(replayed?.status).toBe("partially_paid");
+    expect(Number((replayed as any).amountPaid)).toBe(300);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Skipped replayed Soroban payment event"),
+    );
+
+    warnSpy.mockRestore();
   });
 });

--- a/backend/src/invoices/invoices.service.spec.ts
+++ b/backend/src/invoices/invoices.service.spec.ts
@@ -362,6 +362,30 @@ describe("InvoicesService", () => {
         service.reconcilePayment("invoice-a-1", "GPAYER", "XLM", "", "1000000"),
       ).rejects.toThrow(BadRequestException);
     });
+
+    it("is a no-op when replayed against an already-paid invoice", async () => {
+      const first = await service.reconcilePayment(
+        "invoice-b-1",
+        "GPAYER",
+        "USDC",
+        "GASDF",
+        "200",
+      );
+      expect(first.status).toBe("paid");
+      mockSorobanService.recordInvoicePayment.mockClear();
+
+      const replayed = await service.reconcilePayment(
+        "invoice-b-1",
+        "GPAYER",
+        "USDC",
+        "GASDF",
+        "200",
+      );
+
+      expect(replayed.status).toBe("paid");
+      expect((replayed as any).amountPaid).toBe((first as any).amountPaid);
+      expect(mockSorobanService.recordInvoicePayment).not.toHaveBeenCalled();
+    });
   });
 
   describe("status history audit trail", () => {

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -637,6 +637,24 @@ export class InvoicesService implements OnModuleInit {
       return null;
     }
 
+    const txHash = `soroban:${evt.eventId}`;
+    const contractId = evt.contractId ?? "unknown";
+
+    // Replay guard: this exact (txHash, invoice, contract) combination was
+    // already applied — most likely a redelivered/replayed RPC event.
+    // Skip without touching amountPaid/Payment rows again.
+    const alreadyProcessed = await this.prisma.processedEvent.findUnique({
+      where: {
+        txHash_invoiceId_contractId: { txHash, invoiceId, contractId },
+      },
+    });
+    if (alreadyProcessed) {
+      this.logger.warn(
+        `Skipped replayed Soroban payment event: invoiceId=${invoiceId} eventId=${evt.eventId} txHash=${txHash} — already processed at ${alreadyProcessed.processedAt.toISOString()}`,
+      );
+      return this.normalizeInvoice(existing);
+    }
+
     const sorobanMeta = {
       lastEventId: evt.eventId,
       contractId: evt.contractId ?? null,
@@ -657,36 +675,58 @@ export class InvoicesService implements OnModuleInit {
       const newAmountDue = Math.max(0, currentAmount - newAmountPaid);
       const newStatus = newAmountDue <= 0 ? "paid" : "partially_paid";
 
-      const updated = await this.prisma.invoice.update({
-        where: { id: invoiceId },
-        data: {
-          status: newStatus as any,
-          txHash:
-            newStatus === "paid" ? `soroban:${evt.eventId}` : existing.txHash,
-          amountPaid: newAmountPaid,
-          amountDue: newAmountDue,
-          payments: {
-            create: {
-              amount: paymentAmount,
-              txHash: `soroban:${evt.eventId}`,
+      let updated;
+      try {
+        updated = await this.prisma.invoice.update({
+          where: { id: invoiceId },
+          data: {
+            status: newStatus as any,
+            txHash: newStatus === "paid" ? txHash : existing.txHash,
+            amountPaid: newAmountPaid,
+            amountDue: newAmountDue,
+            payments: {
+              create: {
+                amount: paymentAmount,
+                txHash,
+              },
+            },
+            metadata: {
+              ...((existing.metadata as any) ?? {}),
+              soroban: sorobanMeta,
+            },
+            statusHistory: {
+              create: {
+                status: newStatus as any,
+              },
             },
           },
-          metadata: {
-            ...((existing.metadata as any) ?? {}),
-            soroban: sorobanMeta,
-          },
-          statusHistory: {
-            create: {
-              status: newStatus as any,
+          include: {
+            statusHistory: {
+              orderBy: { createdAt: "asc" },
             },
           },
-        },
-        include: {
-          statusHistory: {
-            orderBy: { createdAt: "asc" },
-          },
-        },
+        });
+      } catch (err) {
+        // Defense-in-depth: a concurrent call recorded this txHash first.
+        // The unique constraint on Payment.txHash caught a replay we
+        // didn't already know about — treat it as a skipped replay.
+        if ((err as { code?: string }).code === "P2002") {
+          this.logger.warn(
+            `Skipped replayed Soroban payment event: invoiceId=${invoiceId} eventId=${evt.eventId} txHash=${txHash} — duplicate Payment.txHash detected`,
+          );
+          return this.normalizeInvoice(existing);
+        }
+        throw err;
+      }
+
+      await this.recordReconciliationDecision({
+        txHash,
+        invoiceId,
+        contractId,
+        ledger: evt.ledger,
+        status: "success",
       });
+
       if (newStatus === "paid") {
         await this.notificationsService.notifyInvoicePaid(updated);
       }
@@ -707,8 +747,39 @@ export class InvoicesService implements OnModuleInit {
           },
         },
       });
+      await this.recordReconciliationDecision({
+        txHash,
+        invoiceId,
+        contractId,
+        ledger: evt.ledger,
+        status: "success",
+      });
       return this.normalizeInvoice(updated);
     }
+  }
+
+  /**
+   * Persist a record of a reconciliation decision for observability/dedup,
+   * mirroring the ledger kept by BackfillService.processEvent.
+   */
+  private async recordReconciliationDecision(params: {
+    txHash: string;
+    invoiceId: string;
+    contractId: string;
+    ledger?: number;
+    status: "success" | "skipped" | "failed";
+    errorMessage?: string;
+  }): Promise<void> {
+    await this.prisma.processedEvent.create({
+      data: {
+        txHash: params.txHash,
+        ledger: BigInt(params.ledger ?? 0),
+        invoiceId: params.invoiceId,
+        contractId: params.contractId,
+        status: params.status,
+        errorMessage: params.errorMessage,
+      },
+    });
   }
 
   /**
@@ -752,6 +823,20 @@ export class InvoicesService implements OnModuleInit {
       throw new BadRequestException(
         `Invoice "${invoiceId}" is cancelled and cannot be paid`,
       );
+    }
+
+    // Replay guard: the invoice is already fully paid in the database.
+    // Re-running reconciliation (e.g. a redelivered webhook/watcher tick)
+    // must not double-count amountPaid or create a duplicate Payment row.
+    if (invoice.status === "paid") {
+      this.logger.warn(
+        `Skipped replayed reconciliation: invoiceId=${invoiceId} is already paid — no changes applied`,
+      );
+      return {
+        ...this.normalizeInvoice(invoice),
+        txHash: invoice.txHash ?? "",
+        ledger: 0,
+      };
     }
 
     const paymentAmount = Number(amount || 0);
@@ -807,7 +892,11 @@ export class InvoicesService implements OnModuleInit {
         payments: {
           create: {
             amount: paymentAmount,
-            txHash: txHash,
+            // Only the final, fully-paid record carries a real on-chain
+            // hash; partial payments have no confirmed hash yet, and
+            // reusing the "pending_full_payment" placeholder across rows
+            // would collide with the unique constraint on Payment.txHash.
+            txHash: newStatus === "paid" ? txHash : null,
           },
         },
         statusHistory: {


### PR DESCRIPTION
Soroban events and reconciliation calls could be redelivered/replayed, causing double-counted amountPaid and duplicate Payment rows. Add a unique constraint on Payment.txHash, a ProcessedEvent-backed replay guard in applySorobanPaymentEvent, a P2002 fallback guard for concurrent writes, and an already-paid early-exit in reconcilePayment.

Closes #168