### PR TITLE
feat: add search and filter controls to invoice list

### DIFF
--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -43,11 +43,13 @@ export class InvoicesController {
     @CurrentUser() user: User,
     @Query("page") page?: string,
     @Query("limit") limit?: string,
+    @Query("search") search?: string,
+    @Query("status") status?: string,
   ): Promise<Invoice[]> {
     const p = page ? parseInt(page, 10) : 1;
     const l = limit ? parseInt(limit, 10) : 20;
     const result = await this.prisma.runWithMerchantScope(user.merchantId, () =>
-      this.invoicesService.findAll(user.merchantId, p, l),
+      this.invoicesService.findAll(user.merchantId, p, l, search, status),
     );
     return result.items;
   }

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -51,6 +51,8 @@ export class InvoicesService implements OnModuleInit {
     merchantId: string,
     page = 1,
     limit = 20,
+    search?: string,
+    status?: string,
   ): Promise<{
     items: Invoice[];
     total: number;
@@ -59,14 +61,32 @@ export class InvoicesService implements OnModuleInit {
     hasMore: boolean;
   }> {
     const skip = (page - 1) * limit;
+
+    // Build where clause from filters
+    const where: Record<string, unknown> = { merchantId };
+
+    if (search && search.trim().length > 0) {
+      const term = search.trim();
+      where["OR"] = [
+        { invoiceNumber: { contains: term, mode: "insensitive" } },
+        { clientName: { contains: term, mode: "insensitive" } },
+        { clientEmail: { contains: term, mode: "insensitive" } },
+        { memo: { contains: term, mode: "insensitive" } },
+      ];
+    }
+
+    if (status && status.trim().length > 0) {
+      where["status"] = status;
+    }
+
     const [items, total] = await Promise.all([
       this.prisma.invoice.findMany({
-        where: { merchantId },
+        where,
         skip,
         take: limit,
         orderBy: { createdAt: "desc" },
       }),
-      this.prisma.invoice.count({ where: { merchantId } }),
+      this.prisma.invoice.count({ where }),
     ]);
 
     const normalizedItems = items.map((inv) => this.normalizeInvoice(inv));

--- a/mobile/app/dashboard.tsx
+++ b/mobile/app/dashboard.tsx
@@ -8,18 +8,55 @@ import {
   Alert,
   RefreshControl,
   AppState,
+  TextInput,
+  ScrollView,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useWalletAuth } from "../hooks/use-wallet-auth";
 import { useInvoicesList, Invoice } from "../lib/invoices";
-import { useMemo, useEffect, useState } from "react";
+import { useMemo, useEffect, useState, useRef } from "react";
 import { getInvoicesLastSynced } from "../lib/cache";
+import {
+  useInvoiceFilters,
+  STATUS_OPTIONS,
+} from "../hooks/use-invoice-filters";
+
+/** Debounce delay for search input (ms) */
+const DEBOUNCE_MS = 350;
 
 export default function DashboardScreen() {
   const router = useRouter();
   const { publicKey, disconnectWallet } = useWalletAuth();
+
+  // Filter state from zustand store (persists across navigation)
+  const {
+    search,
+    searchDraft,
+    status,
+    setSearchDraft,
+    commitDraft,
+    setStatus,
+    clearFilters,
+  } = useInvoiceFilters();
+
+  // Debounce search commits
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleSearchChange = (text: string) => {
+    setSearchDraft(text);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      commitDraft();
+    }, DEBOUNCE_MS);
+  };
+  // Clean up debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
   const { data, isLoading, isFetching, refetch, hasNextPage, fetchNextPage } =
-    useInvoicesList(20);
+    useInvoicesList(20, search, status);
 
   const [lastSynced, setLastSynced] = useState<number | undefined>(undefined);
 
@@ -40,10 +77,9 @@ export default function DashboardScreen() {
   }, []);
 
   useEffect(() => {
-    const sub = AppState.addEventListener("change", (state) => {
-      if (state === "active") {
+    const sub = AppState.addEventListener("change", (appState) => {
+      if (appState === "active") {
         void refetch();
-        // refresh stored timestamp after a short delay to allow onSuccess
         setTimeout(() => {
           void (async () => {
             try {
@@ -81,6 +117,8 @@ export default function DashboardScreen() {
     return { pending, paid };
   }, [invoices]);
 
+  const hasActiveFilters = search.trim().length > 0 || status !== "all";
+
   const handleLogout = () => {
     Alert.alert("Logout", "Are you sure you want to logout?", [
       { text: "Cancel", style: "cancel" },
@@ -108,7 +146,7 @@ export default function DashboardScreen() {
         ListHeaderComponent={
           <View className="px-6 pt-10">
             <View className="flex-row items-center justify-between">
-              <View>
+              <View className="flex-1 pr-3">
                 <Text
                   className="text-sm uppercase tracking-[0.35em] text-[#7dd3fc]"
                   style={{ fontFamily: "SpaceGrotesk_500Medium" }}
@@ -116,7 +154,7 @@ export default function DashboardScreen() {
                   Operator overview
                 </Text>
                 <Text
-                  className="mt-2 text-4xl leading-tight text-white"
+                  className="mt-2 text-3xl leading-tight text-white"
                   style={{ fontFamily: "SpaceGrotesk_700Bold" }}
                 >
                   Base-native receivables in one glass dashboard.
@@ -124,7 +162,7 @@ export default function DashboardScreen() {
               </View>
               <View className="flex-row gap-2">
                 <Pressable
-                  className="rounded-2xl border border-white/20 px-4 py-2"
+                  className="rounded-2xl border border-white/20 px-3 py-2"
                   onPress={() => {
                     router.push("/settings");
                   }}
@@ -133,18 +171,18 @@ export default function DashboardScreen() {
                     className="text-sm text-white"
                     style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
                   >
-                    Settings
+                    ⚙️
                   </Text>
                 </Pressable>
                 <Pressable
-                  className="rounded-2xl border border-red-500/30 px-4 py-2"
+                  className="rounded-2xl border border-red-500/30 px-3 py-2"
                   onPress={handleLogout}
                 >
                   <Text
                     className="text-sm text-red-400"
                     style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
                   >
-                    Logout
+                    ↗
                   </Text>
                 </Pressable>
               </View>
@@ -157,42 +195,29 @@ export default function DashboardScreen() {
                 Connected: {publicKey.slice(0, 6)}...{publicKey.slice(-4)}
               </Text>
             )}
-            <Text
-              className="mt-2 text-base text-slate-300"
-              style={{ fontFamily: "SpaceGrotesk_400Regular" }}
-            >
-              Monitor liquidity, financing pipelines, and live settlement
-              metrics in real time.
-            </Text>
 
+            {/* Summary cards */}
             <FlatList
               data={[
                 {
                   label: "Total Pending Amount",
                   value:
                     totals.pending > 0
-                      ? `$${totals.pending.toLocaleString(undefined, {
-                          maximumFractionDigits: 2,
-                        })}`
+                      ? `$${totals.pending.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
                       : "$0",
                 },
                 {
                   label: "Total Paid",
                   value:
                     totals.paid > 0
-                      ? `$${totals.paid.toLocaleString(undefined, {
-                          maximumFractionDigits: 2,
-                        })}`
+                      ? `$${totals.paid.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
                       : "$0",
                 },
               ]}
               keyExtractor={(item) => item.label}
               horizontal
               showsHorizontalScrollIndicator={false}
-              contentContainerStyle={{
-                paddingVertical: 20,
-                gap: 16,
-              }}
+              contentContainerStyle={{ paddingVertical: 20, gap: 16 }}
               renderItem={({ item }) => (
                 <LinearGradient
                   colors={["#111C36", "#0F172A"]}
@@ -214,13 +239,89 @@ export default function DashboardScreen() {
               )}
             />
 
+            {/* Search bar */}
+            <View className="mt-2 flex-row items-center rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+              <Text className="mr-2 text-base text-slate-400">🔍</Text>
+              <TextInput
+                className="flex-1 text-base text-white"
+                style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+                placeholder="Search by invoice #, client name, email..."
+                placeholderTextColor="#64748b"
+                value={searchDraft}
+                onChangeText={handleSearchChange}
+                returnKeyType="search"
+                onSubmitEditing={() => {
+                  if (debounceRef.current) clearTimeout(debounceRef.current);
+                  commitDraft();
+                }}
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+              {searchDraft.length > 0 && (
+                <Pressable
+                  onPress={() => {
+                    setSearchDraft("");
+                    if (debounceRef.current) clearTimeout(debounceRef.current);
+                    commitDraft();
+                  }}
+                >
+                  <Text className="text-base text-slate-400">✕</Text>
+                </Pressable>
+              )}
+            </View>
+
+            {/* Status filter chips */}
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={{ gap: 8, paddingVertical: 12 }}
+            >
+              {STATUS_OPTIONS.map((opt) => {
+                const isActive = status === opt.value;
+                return (
+                  <Pressable
+                    key={opt.value}
+                    className={`rounded-full px-4 py-2 ${
+                      isActive
+                        ? "bg-[#2663FF]"
+                        : "border border-white/20 bg-transparent"
+                    }`}
+                    onPress={() => {
+                      setStatus(opt.value);
+                    }}
+                  >
+                    <Text
+                      className={`text-sm ${isActive ? "text-white" : "text-slate-300"}`}
+                      style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+                    >
+                      {opt.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+              {hasActiveFilters && (
+                <Pressable
+                  className="rounded-full border border-red-500/40 px-3 py-2"
+                  onPress={clearFilters}
+                >
+                  <Text
+                    className="text-sm text-red-400"
+                    style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+                  >
+                    Clear all
+                  </Text>
+                </Pressable>
+              )}
+            </ScrollView>
+
+            {/* Section header */}
             <View>
               <View className="flex-row items-center justify-between">
                 <Text
                   className="text-lg text-white"
                   style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
                 >
-                  Active invoices
+                  {hasActiveFilters ? "Filtered results" : "Active invoices"}
                 </Text>
                 <View className="flex-row gap-2">
                   <Pressable
@@ -266,13 +367,25 @@ export default function DashboardScreen() {
               ? "bg-yellow-500/20"
               : item.status === "paid"
                 ? "bg-emerald-500/20"
-                : "bg-red-500/20";
+                : item.status === "overdue"
+                  ? "bg-red-500/20"
+                  : "bg-slate-500/20";
           const statusText =
             item.status === "pending"
               ? "text-yellow-300"
               : item.status === "paid"
                 ? "text-emerald-300"
-                : "text-red-300";
+                : item.status === "overdue"
+                  ? "text-red-300"
+                  : "text-slate-300";
+          const statusLabel =
+            item.status === "pending"
+              ? "Pending"
+              : item.status === "paid"
+                ? "Paid"
+                : item.status === "overdue"
+                  ? "Overdue"
+                  : "Cancelled";
           return (
             <Pressable
               className="mx-6 my-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-4"
@@ -295,6 +408,15 @@ export default function DashboardScreen() {
                   >
                     {item.clientName ?? "Invoice"}
                   </Text>
+                  {item.clientEmail ? (
+                    <Text
+                      className="mt-0.5 text-xs text-slate-500"
+                      style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+                      numberOfLines={1}
+                    >
+                      {item.clientEmail}
+                    </Text>
+                  ) : null}
                   <Text
                     className="mt-1 text-xs text-slate-400"
                     style={{ fontFamily: "SpaceGrotesk_400Regular" }}
@@ -323,11 +445,7 @@ export default function DashboardScreen() {
                       className={`text-xs ${statusText}`}
                       style={{ fontFamily: "SpaceGrotesk_500Medium" }}
                     >
-                      {item.status === "pending"
-                        ? "Pending"
-                        : item.status === "paid"
-                          ? "Paid"
-                          : "Expired"}
+                      {statusLabel}
                     </Text>
                   </View>
                 </View>
@@ -345,16 +463,50 @@ export default function DashboardScreen() {
                 />
               ))}
             </View>
-          ) : (
-            <View className="px-6 py-12 items-center">
+          ) : hasActiveFilters ? (
+            <View className="items-center px-6 py-12">
               <Text
-                className="text-slate-400"
+                className="text-xl text-white"
+                style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
+              >
+                No matching invoices
+              </Text>
+              <Text
+                className="mt-2 text-center text-sm text-slate-400"
                 style={{ fontFamily: "SpaceGrotesk_400Regular" }}
               >
-                No invoices found
+                {search.trim().length > 0
+                  ? `No results for "${search.trim()}".`
+                  : "No invoices match the selected filter."}
+              </Text>
+              <Pressable
+                className="mt-4 rounded-2xl border border-white/20 px-5 py-2"
+                onPress={clearFilters}
+              >
+                <Text
+                  className="text-white"
+                  style={{ fontFamily: "SpaceGrotesk_500Medium" }}
+                >
+                  Clear filters
+                </Text>
+              </Pressable>
+            </View>
+          ) : (
+            <View className="items-center px-6 py-12">
+              <Text
+                className="text-xl text-white"
+                style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}
+              >
+                No invoices yet
+              </Text>
+              <Text
+                className="mt-2 text-center text-sm text-slate-400"
+                style={{ fontFamily: "SpaceGrotesk_400Regular" }}
+              >
+                Create your first invoice to start tracking payments on-chain.
               </Text>
               <Link href="/create-invoice" asChild>
-                <Pressable className="mt-4 rounded-2xl border border-white/20 px-4 py-2">
+                <Pressable className="mt-4 rounded-2xl bg-[#2663FF] px-5 py-2">
                   <Text
                     className="text-white"
                     style={{ fontFamily: "SpaceGrotesk_500Medium" }}

--- a/mobile/hooks/use-invoice-filters.ts
+++ b/mobile/hooks/use-invoice-filters.ts
@@ -1,0 +1,56 @@
+import { create } from "zustand";
+import type { InvoiceStatus } from "../lib/invoices";
+
+/**
+ * All filterable status options including "all" for the no-filter state.
+ */
+export type StatusFilter = "all" | InvoiceStatus;
+
+export const STATUS_OPTIONS: { label: string; value: StatusFilter }[] = [
+  { label: "All", value: "all" },
+  { label: "Pending", value: "pending" },
+  { label: "Paid", value: "paid" },
+  { label: "Overdue", value: "overdue" },
+  { label: "Cancelled", value: "cancelled" },
+];
+
+interface InvoiceFiltersState {
+  /** Debounced search query sent to the API */
+  search: string;
+  /** Status filter (null = all) */
+  status: StatusFilter;
+  /** Transient text in the search input (not yet debounced) */
+  searchDraft: string;
+
+  setSearch: (value: string) => void;
+  setSearchDraft: (value: string) => void;
+  commitDraft: () => void;
+  setStatus: (status: StatusFilter) => void;
+  clearFilters: () => void;
+}
+
+/**
+ * Persistent filter state for the invoice list.
+ * Survives screen navigation since zustand stores are module-scoped singletons.
+ */
+export const useInvoiceFilters = create<InvoiceFiltersState>((set) => ({
+  search: "",
+  status: "all",
+  searchDraft: "",
+
+  setSearch: (value) => {
+    set({ search: value });
+  },
+  setSearchDraft: (value) => {
+    set({ searchDraft: value });
+  },
+  commitDraft: () => {
+    set((state) => ({ search: state.searchDraft }));
+  },
+  setStatus: (status) => {
+    set({ status });
+  },
+  clearFilters: () => {
+    set({ search: "", searchDraft: "", status: "all" });
+  },
+}));

--- a/mobile/lib/invoices.ts
+++ b/mobile/lib/invoices.ts
@@ -5,7 +5,7 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { setCachedInvoices, getCachedInvoices } from "./cache";
 
-export type InvoiceStatus = "pending" | "paid" | "expired";
+export type InvoiceStatus = "pending" | "paid" | "overdue" | "cancelled";
 
 export interface Invoice {
   id: string;
@@ -39,6 +39,8 @@ async function fetchInvoicesPage(
   page: number,
   pageSize: number,
   token: string | null,
+  search?: string,
+  status?: string,
 ): Promise<InvoicesPage> {
   const headers =
     token != null
@@ -50,8 +52,14 @@ async function fetchInvoicesPage(
   const params = new URLSearchParams({
     page: String(page),
     limit: String(pageSize),
-  }).toString();
-  const url = `${API_URL}/invoices?${params}`;
+  });
+  if (search && search.trim().length > 0) {
+    params.set("search", search.trim());
+  }
+  if (status && status !== "all") {
+    params.set("status", status);
+  }
+  const url = `${API_URL}/invoices?${params.toString()}`;
   const response = await axios.get(url, headers ? { headers } : undefined);
   const data: unknown = response.data;
 
@@ -88,9 +96,18 @@ async function fetchInvoicesPage(
     : { items, page, pageSize, hasMore };
 }
 
-export function useInvoicesList(pageSize = 20) {
+export function useInvoicesList(
+  pageSize = 20,
+  search?: string,
+  status?: string,
+) {
   const { accessToken } = useAuthStore();
   const queryClient = useQueryClient();
+
+  // Derive effective filter values
+  const effectiveSearch =
+    search && search.trim().length > 0 ? search.trim() : undefined;
+  const effectiveStatus = status && status !== "all" ? status : undefined;
 
   // seed cached data (if any) into the query cache so UI can show offline data
   // without blocking the hook caller. Read AsyncStorage in effect and set
@@ -102,10 +119,19 @@ export function useInvoicesList(pageSize = 20) {
         const cached = await getCachedInvoices();
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- cancelled may be mutated by cleanup
         if (!cancelled && cached?.pages) {
-          queryClient.setQueryData(["invoices", pageSize, accessToken], {
-            pages: cached.pages,
-            pageParams: cached.pages.map((_, i) => i + 1),
-          });
+          queryClient.setQueryData(
+            [
+              "invoices",
+              pageSize,
+              accessToken,
+              effectiveSearch,
+              effectiveStatus,
+            ],
+            {
+              pages: cached.pages,
+              pageParams: cached.pages.map((_, i) => i + 1),
+            },
+          );
         }
       } catch (err) {
         console.error("seed cache error:", err);
@@ -114,12 +140,24 @@ export function useInvoicesList(pageSize = 20) {
     return () => {
       cancelled = true;
     };
-  }, [accessToken, pageSize, queryClient]);
+  }, [accessToken, pageSize, queryClient, effectiveSearch, effectiveStatus]);
 
   const query = useInfiniteQuery({
-    queryKey: ["invoices", pageSize, accessToken],
+    queryKey: [
+      "invoices",
+      pageSize,
+      accessToken,
+      effectiveSearch,
+      effectiveStatus,
+    ],
     queryFn: async ({ pageParam }: { pageParam: number }) =>
-      fetchInvoicesPage(pageParam, pageSize, accessToken),
+      fetchInvoicesPage(
+        pageParam,
+        pageSize,
+        accessToken,
+        effectiveSearch,
+        effectiveStatus,
+      ),
     initialPageParam: 1,
     getNextPageParam: (lastPage) =>
       lastPage.hasMore ? lastPage.page + 1 : undefined,


### PR DESCRIPTION
Closes #145 
- Backend: extend GET /invoices with search and status query params
- Backend: case-insensitive search across invoiceNumber, clientName, clientEmail, memo
- Mobile: add zustand filter store (persists across screen navigation)
- Mobile: add search bar with 350ms debounce to dashboard
- Mobile: add horizontal status filter chips (All/Pending/Paid/Overdue/Cancelled)
- Mobile: three context-aware empty states (loading, no-results, no-invoices)
- Fix InvoiceStatus type to match Prisma enum (overdue/cancelled instead of expired)
- Show client email in invoice list cards