### PR TITLE
Add invoice and receipt PDF exports

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -112,6 +112,17 @@ GET /invoices
 GET /invoices/:id
 ```
 
+#### Download invoice and receipt PDFs
+
+```bash
+GET /invoices/:id/export.pdf
+GET /invoices/:id/receipt.pdf
+```
+
+Both endpoints require authentication, are scoped to the caller's merchant, and
+return `application/pdf` attachments with stable filenames such as
+`invoice-INV-001.pdf` and `receipt-INV-001.pdf`.
+
 #### Create a new invoice
 
 ```bash
@@ -249,7 +260,7 @@ The `StellarModule` currently provides stubbed methods. Future implementation wi
 - [ ] Horizon payment streaming
 - [ ] Soroban smart contract integration
 - [ ] Email notifications
-- [ ] PDF invoice generation
+- [x] PDF invoice and receipt generation
 - [ ] Webhook support
 
 ## License

--- a/backend/src/invoices/entities/invoice.entity.ts
+++ b/backend/src/invoices/entities/invoice.entity.ts
@@ -20,6 +20,14 @@ export class Invoice {
 
   merchantId?: string;
 
+  merchant?: {
+    id: string;
+    name: string;
+    stellarPublicKey: string;
+    payoutPublicKey?: string | null;
+    preferredAsset?: string | null;
+  } | null;
+
   user?: User | null;
 
   invoiceNumber?: string | null;

--- a/backend/src/invoices/invoice-pdf.service.spec.ts
+++ b/backend/src/invoices/invoice-pdf.service.spec.ts
@@ -1,0 +1,93 @@
+import { InvoicePdfService } from "./invoice-pdf.service";
+import { Invoice } from "./entities/invoice.entity";
+
+describe("InvoicePdfService", () => {
+  const service = new InvoicePdfService();
+
+  const baseInvoice: Invoice = {
+    id: "invoice-123",
+    merchantId: "merchant-123",
+    merchant: {
+      id: "merchant-123",
+      name: "Acme Billing",
+      stellarPublicKey:
+        "GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      payoutPublicKey: null,
+      preferredAsset: "USDC",
+    },
+    invoiceNumber: "INV/2026 001",
+    clientName: "Client Co",
+    clientEmail: "ap@client.example",
+    description: "Integration services",
+    amount: 2500,
+    amountPaid: 0,
+    amountDue: 2500,
+    asset_code: "USDC",
+    asset_issuer: null,
+    memo: "123456789",
+    memo_type: "ID",
+    tx_hash: null,
+    status: "pending",
+    destination_address:
+      "GDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    createdAt: new Date("2026-07-01T10:00:00Z"),
+    updatedAt: new Date("2026-07-02T10:00:00Z"),
+    dueDate: new Date("2026-07-31T23:59:59Z"),
+    statusHistory: [
+      {
+        id: "hist-1",
+        invoiceId: "invoice-123",
+        status: "pending",
+        createdAt: new Date("2026-07-01T10:00:00Z"),
+      },
+    ],
+    payments: [],
+  };
+
+  it("renders a valid invoice PDF with a stable sanitized filename", () => {
+    const document = service.createInvoiceExport(baseInvoice);
+    const pdf = document.buffer.toString("utf8");
+
+    expect(document.filename).toBe("invoice-INV-2026-001.pdf");
+    expect(document.buffer.subarray(0, 8).toString()).toBe("%PDF-1.4");
+    expect(pdf).toContain("Invoice Export");
+    expect(pdf).toContain("Merchant: Acme Billing");
+    expect(pdf).toContain("Status: pending");
+    expect(pdf).toContain("Unpaid or pending");
+  });
+
+  it("renders paid receipt content and payment rows", () => {
+    const paidInvoice: Invoice = {
+      ...baseInvoice,
+      status: "paid",
+      amountPaid: 2500,
+      amountDue: 0,
+      tx_hash: "tx-paid",
+      payments: [
+        {
+          id: "payment-1",
+          amount: 2500,
+          txHash: "tx-paid",
+          createdAt: new Date("2026-07-03T11:00:00Z"),
+        },
+      ],
+      statusHistory: [
+        ...(baseInvoice.statusHistory ?? []),
+        {
+          id: "hist-2",
+          invoiceId: "invoice-123",
+          status: "paid",
+          createdAt: new Date("2026-07-03T11:00:00Z"),
+        },
+      ],
+    };
+
+    const document = service.createReceipt(paidInvoice);
+    const pdf = document.buffer.toString("utf8");
+
+    expect(document.filename).toBe("receipt-INV-2026-001.pdf");
+    expect(pdf).toContain("Payment Receipt");
+    expect(pdf).toContain("Paid in full");
+    expect(pdf).toContain("tx-paid");
+  });
+});

--- a/backend/src/invoices/invoice-pdf.service.ts
+++ b/backend/src/invoices/invoice-pdf.service.ts
@@ -1,0 +1,205 @@
+import { Injectable } from "@nestjs/common";
+import { Invoice } from "./entities/invoice.entity";
+
+export type InvoicePdfKind = "invoice" | "receipt";
+
+export interface InvoicePdfDocument {
+  filename: string;
+  buffer: Buffer;
+}
+
+@Injectable()
+export class InvoicePdfService {
+  createInvoiceExport(invoice: Invoice): InvoicePdfDocument {
+    return this.createDocument(invoice, "invoice");
+  }
+
+  createReceipt(invoice: Invoice): InvoicePdfDocument {
+    return this.createDocument(invoice, "receipt");
+  }
+
+  private createDocument(
+    invoice: Invoice,
+    kind: InvoicePdfKind,
+  ): InvoicePdfDocument {
+    const invoiceNumber = invoice.invoiceNumber || invoice.id;
+    const filenamePrefix = kind === "invoice" ? "invoice" : "receipt";
+    const title = kind === "invoice" ? "Invoice Export" : "Payment Receipt";
+    const merchantName = invoice.merchant?.name || "Invoisio Merchant";
+    const amount = this.formatMoney(invoice.amount, invoice.asset_code);
+    const amountPaid = this.formatMoney(
+      invoice.amountPaid ?? 0,
+      invoice.asset_code,
+    );
+    const amountDue = this.formatMoney(
+      invoice.amountDue ?? 0,
+      invoice.asset_code,
+    );
+
+    const lines = [
+      title,
+      `Merchant: ${merchantName}`,
+      `Invoice number: ${invoiceNumber}`,
+      `Invoice ID: ${invoice.id}`,
+      `Client: ${invoice.clientName}`,
+      `Client email: ${invoice.clientEmail || "n/a"}`,
+      `Status: ${invoice.status}`,
+      `Amount: ${amount}`,
+      `Amount paid: ${amountPaid}`,
+      `Amount due: ${amountDue}`,
+      `Asset: ${invoice.asset_code}`,
+      `Memo: ${invoice.memo}`,
+      `Destination: ${invoice.destination_address || "n/a"}`,
+      `Merchant Stellar key: ${invoice.merchant?.stellarPublicKey || "n/a"}`,
+      `Preferred merchant asset: ${invoice.merchant?.preferredAsset || "n/a"}`,
+      `Due date: ${this.formatDate(invoice.dueDate)}`,
+      `Created: ${this.formatDate(invoice.createdAt)}`,
+      `Updated: ${this.formatDate(invoice.updatedAt)}`,
+      `Transaction hash: ${invoice.tx_hash || "n/a"}`,
+      `Soroban transaction: ${(invoice as any).sorobanTxHash || "n/a"}`,
+      "",
+      "Description",
+      invoice.description || "n/a",
+      "",
+      "Payment status",
+      this.paymentSummary(invoice),
+      "",
+      "Status history",
+      ...this.statusHistoryLines(invoice),
+      "",
+      "Payments",
+      ...this.paymentLines(invoice),
+    ];
+
+    return {
+      filename: `${filenamePrefix}-${this.safeFilename(invoiceNumber)}.pdf`,
+      buffer: this.renderPdf(lines),
+    };
+  }
+
+  private formatMoney(
+    value: string | number | undefined,
+    asset: string,
+  ): string {
+    const numeric = Number(value ?? 0);
+    if (Number.isFinite(numeric)) {
+      return `${numeric.toFixed(7).replace(/\.?0+$/, "")} ${asset}`;
+    }
+    return `${String(value ?? 0)} ${asset}`;
+  }
+
+  private formatDate(value: Date | string | null | undefined): string {
+    if (!value) return "n/a";
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) return "n/a";
+    return date.toISOString();
+  }
+
+  private paymentSummary(invoice: Invoice): string {
+    if (invoice.status === "paid") {
+      return "Paid in full";
+    }
+    if (invoice.status === "partially_paid" || invoice.status === "partial") {
+      return "Partially paid";
+    }
+    return "Unpaid or pending";
+  }
+
+  private statusHistoryLines(invoice: Invoice): string[] {
+    if (!invoice.statusHistory || invoice.statusHistory.length === 0) {
+      return ["No status history recorded"];
+    }
+    return invoice.statusHistory.map(
+      (entry) => `${this.formatDate(entry.createdAt)} - ${entry.status}`,
+    );
+  }
+
+  private paymentLines(invoice: Invoice): string[] {
+    if (!invoice.payments || invoice.payments.length === 0) {
+      return ["No payments recorded"];
+    }
+    return invoice.payments.map((payment) => {
+      const amount = this.formatMoney(payment.amount, invoice.asset_code);
+      return `${this.formatDate(payment.createdAt)} - ${amount} - ${
+        payment.txHash || "no tx hash"
+      }`;
+    });
+  }
+
+  private safeFilename(value: string): string {
+    const safe = value
+      .trim()
+      .replace(/[^A-Za-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80);
+    return safe || "invoice";
+  }
+
+  private renderPdf(lines: string[]): Buffer {
+    const wrappedLines = lines.flatMap((line) => this.wrapLine(line, 86));
+    const content = this.buildPageContent(wrappedLines);
+    const objects = [
+      "<< /Type /Catalog /Pages 2 0 R >>",
+      "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+      "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+      "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+      `<< /Length ${Buffer.byteLength(
+        content,
+        "utf8",
+      )} >>\nstream\n${content}\nendstream`,
+    ];
+
+    let pdf = "%PDF-1.4\n";
+    const offsets = [0];
+    for (let index = 0; index < objects.length; index++) {
+      offsets.push(Buffer.byteLength(pdf, "utf8"));
+      pdf += `${index + 1} 0 obj\n${objects[index]}\nendobj\n`;
+    }
+
+    const xrefOffset = Buffer.byteLength(pdf, "utf8");
+    pdf += `xref\n0 ${objects.length + 1}\n`;
+    pdf += "0000000000 65535 f \n";
+    for (let index = 1; index < offsets.length; index++) {
+      pdf += `${String(offsets[index]).padStart(10, "0")} 00000 n \n`;
+    }
+    pdf += `trailer\n<< /Size ${
+      objects.length + 1
+    } /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+    return Buffer.from(pdf, "utf8");
+  }
+
+  private buildPageContent(lines: string[]): string {
+    const printableLines = lines.slice(0, 48);
+    const content = ["BT", "/F1 11 Tf", "72 740 Td", "14 TL"];
+    printableLines.forEach((line, index) => {
+      if (index > 0) {
+        content.push("T*");
+      }
+      const safeLine = line.replace(/[^\x20-\x7E]/g, "?");
+      content.push(`(${this.escapePdfText(safeLine)}) Tj`);
+    });
+    content.push("ET");
+    return content.join("\n");
+  }
+
+  private wrapLine(line: string, width: number): string[] {
+    if (line.length <= width) return [line];
+    const result: string[] = [];
+    let remaining = line;
+    while (remaining.length > width) {
+      let breakAt = remaining.lastIndexOf(" ", width);
+      if (breakAt <= 0) breakAt = width;
+      result.push(remaining.slice(0, breakAt));
+      remaining = remaining.slice(breakAt).trimStart();
+    }
+    if (remaining.length > 0) result.push(remaining);
+    return result;
+  }
+
+  private escapePdfText(value: string): string {
+    return value
+      .replace(/\\/g, "\\\\")
+      .replace(/\(/g, "\\(")
+      .replace(/\)/g, "\\)");
+  }
+}

--- a/backend/src/invoices/invoices.controller.spec.ts
+++ b/backend/src/invoices/invoices.controller.spec.ts
@@ -1,0 +1,115 @@
+import { InvoicesController } from "./invoices.controller";
+import { InvoicePdfService } from "./invoice-pdf.service";
+import { Invoice } from "./entities/invoice.entity";
+
+describe("InvoicesController PDF exports", () => {
+  const invoice: Invoice = {
+    id: "invoice-123",
+    merchantId: "merchant-123",
+    invoiceNumber: "INV-001",
+    clientName: "Client Co",
+    clientEmail: "ap@client.example",
+    description: "Services",
+    amount: 100,
+    amountPaid: 100,
+    amountDue: 0,
+    asset_code: "USDC",
+    memo: "123",
+    memo_type: "ID",
+    status: "paid",
+  };
+
+  const invoicesService = {
+    findOne: jest.fn().mockResolvedValue(invoice),
+  };
+
+  const prisma = {
+    runWithMerchantScope: jest
+      .fn()
+      .mockImplementation(
+        (_merchantId: string, callback: () => Promise<Invoice>) => callback(),
+      ),
+  };
+
+  const pdfService = {
+    createInvoiceExport: jest.fn().mockReturnValue({
+      filename: "invoice-INV-001.pdf",
+      buffer: Buffer.from("%PDF-1.4 invoice"),
+    }),
+    createReceipt: jest.fn().mockReturnValue({
+      filename: "receipt-INV-001.pdf",
+      buffer: Buffer.from("%PDF-1.4 receipt"),
+    }),
+  };
+
+  let controller: InvoicesController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new InvoicesController(
+      invoicesService as any,
+      prisma as any,
+      pdfService as unknown as InvoicePdfService,
+    );
+  });
+
+  it("returns a merchant-scoped invoice PDF download", async () => {
+    const response = { setHeader: jest.fn() };
+
+    const buffer = await controller.exportInvoicePdf(
+      {
+        id: "user-123",
+        merchantId: "merchant-123",
+        publicKey: "G",
+        isAdmin: false,
+      },
+      "invoice-123",
+      response as any,
+    );
+
+    expect(prisma.runWithMerchantScope).toHaveBeenCalledWith(
+      "merchant-123",
+      expect.any(Function),
+    );
+    expect(invoicesService.findOne).toHaveBeenCalledWith(
+      "invoice-123",
+      "merchant-123",
+    );
+    expect(pdfService.createInvoiceExport).toHaveBeenCalledWith(invoice);
+    expect(buffer.toString()).toContain("%PDF-1.4");
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Type",
+      "application/pdf",
+    );
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      'attachment; filename="invoice-INV-001.pdf"',
+    );
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Cache-Control",
+      "private, no-store",
+    );
+  });
+
+  it("returns a merchant-scoped receipt PDF download", async () => {
+    const response = { setHeader: jest.fn() };
+
+    const buffer = await controller.exportReceiptPdf(
+      {
+        id: "user-123",
+        merchantId: "merchant-123",
+        publicKey: "G",
+        isAdmin: false,
+      },
+      "invoice-123",
+      response as any,
+    );
+
+    expect(pdfService.createReceipt).toHaveBeenCalledWith(invoice);
+    expect(buffer.toString()).toContain("%PDF-1.4");
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      'attachment; filename="receipt-INV-001.pdf"',
+    );
+  });
+});

--- a/backend/src/invoices/invoices.controller.ts
+++ b/backend/src/invoices/invoices.controller.ts
@@ -9,7 +9,9 @@ import {
   UseInterceptors,
   UploadedFile,
   BadRequestException,
+  Res,
 } from "@nestjs/common";
+import type { Response } from "express";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { memoryStorage } from "multer";
 import { Throttle } from "@nestjs/throttler";
@@ -22,6 +24,7 @@ import { InvoiceStatus } from "@prisma/client";
 import { Auth, CurrentUser } from "../auth/guard/auth.guard";
 import { User } from "../users/user.entity";
 import { PrismaService } from "../prisma/prisma.service";
+import { InvoicePdfDocument, InvoicePdfService } from "./invoice-pdf.service";
 
 /**
  * Invoices controller
@@ -37,6 +40,7 @@ export class InvoicesController {
   constructor(
     private readonly invoicesService: InvoicesService,
     private readonly prisma: PrismaService,
+    private readonly invoicePdfService: InvoicePdfService,
   ) {}
 
   /**
@@ -80,6 +84,38 @@ export class InvoicesController {
    * @param id - Invoice UUID
    * @returns The invoice object
    */
+  @Auth()
+  @Get(":id/export.pdf")
+  async exportInvoicePdf(
+    @CurrentUser() user: User,
+    @Param("id") id: string,
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<Buffer> {
+    const invoice = await this.prisma.runWithMerchantScope(
+      user.merchantId,
+      () => this.invoicesService.findOne(id, user.merchantId),
+    );
+    const document = this.invoicePdfService.createInvoiceExport(invoice);
+    this.setPdfDownloadHeaders(response, document);
+    return document.buffer;
+  }
+
+  @Auth()
+  @Get(":id/receipt.pdf")
+  async exportReceiptPdf(
+    @CurrentUser() user: User,
+    @Param("id") id: string,
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<Buffer> {
+    const invoice = await this.prisma.runWithMerchantScope(
+      user.merchantId,
+      () => this.invoicesService.findOne(id, user.merchantId),
+    );
+    const document = this.invoicePdfService.createReceipt(invoice);
+    this.setPdfDownloadHeaders(response, document);
+    return document.buffer;
+  }
+
   @Auth()
   @Get(":id")
   async findOne(
@@ -210,5 +246,18 @@ export class InvoicesController {
         reason ?? "voided",
       ),
     );
+  }
+
+  private setPdfDownloadHeaders(
+    response: Response,
+    document: InvoicePdfDocument,
+  ): void {
+    response.setHeader("Content-Type", "application/pdf");
+    response.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${document.filename}"`,
+    );
+    response.setHeader("Content-Length", String(document.buffer.length));
+    response.setHeader("Cache-Control", "private, no-store");
   }
 }

--- a/backend/src/invoices/invoices.module.ts
+++ b/backend/src/invoices/invoices.module.ts
@@ -8,6 +8,7 @@ import { WebhooksModule } from "../webhooks/webhooks.module";
 import { AuthModule } from "../auth/auth.module";
 import { NotificationsModule } from "../notifications/notifications.module";
 import { RealtimeModule } from "../realtime/realtime.module";
+import { InvoicePdfService } from "./invoice-pdf.service";
 
 /**
  * Invoices module
@@ -24,7 +25,7 @@ import { RealtimeModule } from "../realtime/realtime.module";
     RealtimeModule,
   ],
   controllers: [InvoicesController],
-  providers: [InvoicesService],
-  exports: [InvoicesService],
+  providers: [InvoicesService, InvoicePdfService],
+  exports: [InvoicesService, InvoicePdfService],
 })
 export class InvoicesModule {}

--- a/backend/src/invoices/invoices.service.ts
+++ b/backend/src/invoices/invoices.service.ts
@@ -257,6 +257,10 @@ export class InvoicesService implements OnModuleInit {
     const invoice = await this.prisma.invoice.findFirst({
       where: { id, merchantId },
       include: {
+        merchant: true,
+        payments: {
+          orderBy: { createdAt: "asc" },
+        },
         statusHistory: {
           orderBy: { createdAt: "asc" },
         },
@@ -959,7 +963,7 @@ export class InvoicesService implements OnModuleInit {
     } else {
       await this.webhooksService.enqueueWebhook(
         invoice.id,
-        "partially_paid" as any,
+        "partially_paid",
         txHash,
         invoice.merchantId,
       );
@@ -1029,7 +1033,7 @@ export class InvoicesService implements OnModuleInit {
 
     await this.webhooksService.enqueueWebhook(
       id,
-      "cancelled" as any,
+      "cancelled",
       invoice.txHash,
       merchantId,
     );


### PR DESCRIPTION
Closes ZyntariHQ/Invoisio#125.

## Summary

- add authenticated merchant-scoped PDF download endpoints for invoices and receipts:
  - `GET /invoices/:id/export.pdf`
  - `GET /invoices/:id/receipt.pdf`
- add an `InvoicePdfService` that produces dependency-free PDF buffers with merchant branding, invoice metadata, memo/payment details, status history, and paid/unpaid status summaries
- include merchant and payment rows in invoice detail loading so exports can render branded and payment-aware documents
- document the new endpoints in the backend README

## Validation

- `node node_modules/prisma/build/index.js generate`
- `node node_modules/jest/bin/jest.js invoices/invoice-pdf.service.spec.ts invoices/invoices.controller.spec.ts invoices/invoices.service.spec.ts --runInBand`
- `node node_modules/eslint/bin/eslint.js src/invoices/invoice-pdf.service.ts src/invoices/invoice-pdf.service.spec.ts src/invoices/invoices.controller.ts src/invoices/invoices.controller.spec.ts src/invoices/invoices.service.ts src/invoices/entities/invoice.entity.ts`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false`
- `node node_modules/@nestjs/cli/bin/nest.js build`
- `git diff --check`

## Notes

The PDF renderer is intentionally dependency-free to keep the backend install surface unchanged while still returning valid `application/pdf` attachments with stable filenames.
