### PR TITLE
Add dead-letter queue for failed webhook deliveries

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -155,6 +155,26 @@ POST /webhooks/secret/rotate
 
 The rotate endpoint generates a fresh signing secret, persists it immediately, and returns the raw value once so the merchant can update their webhook receiver. Subsequent reads only return masked metadata.
 
+#### Dead-letter recovery
+
+Failed webhook deliveries now move into a dead-letter table after 5 exhausted attempts instead of remaining in the active queue. Admins can inspect preserved payloads, failure metadata, and retry history with:
+
+```bash
+GET /admin/webhooks/dead-letter
+GET /admin/webhooks/dead-letter/:id
+```
+
+Manual recovery re-queues the stored payload for delivery and keeps the dead-letter record for debugging:
+
+```bash
+POST /admin/webhooks/dead-letter/:id/retry
+```
+
+Recommended manual retry flow:
+1. Inspect the dead-letter entry and fix the downstream webhook endpoint or credentials first.
+2. Re-queue the delivery with `POST /admin/webhooks/dead-letter/:id/retry`.
+3. Confirm the retried delivery transitions to `success` and the dead-letter record becomes `recovered`.
+
 ## Testing
 
 ### Unit Tests

--- a/backend/prisma/migrations/20260716000100_add_webhook_dead_letter_queue/migration.sql
+++ b/backend/prisma/migrations/20260716000100_add_webhook_dead_letter_queue/migration.sql
@@ -1,0 +1,47 @@
+-- CreateEnum
+CREATE TYPE "DeadLetterStatus" AS ENUM ('pending_retry', 'requeued', 'recovered');
+
+-- AlterTable
+ALTER TABLE "webhook_deliveries"
+ADD COLUMN "dead_letter_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "webhook_dead_letters" (
+    "id" TEXT NOT NULL,
+    "original_delivery_id" TEXT NOT NULL,
+    "invoice_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "merchant_id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "last_error" TEXT,
+    "last_http_status" INTEGER,
+    "failed_attempts" INTEGER NOT NULL,
+    "exhausted_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "manual_retry_count" INTEGER NOT NULL DEFAULT 0,
+    "last_retried_at" TIMESTAMP(3),
+    "recovered_at" TIMESTAMP(3),
+    "status" "DeadLetterStatus" NOT NULL DEFAULT 'pending_retry',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "webhook_dead_letters_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "webhook_dead_letters_original_delivery_id_key" ON "webhook_dead_letters"("original_delivery_id");
+
+-- CreateIndex
+CREATE INDEX "webhook_dead_letters_merchant_id_idx" ON "webhook_dead_letters"("merchant_id");
+
+-- CreateIndex
+CREATE INDEX "webhook_dead_letters_status_exhausted_at_idx" ON "webhook_dead_letters"("status", "exhausted_at");
+
+-- AddForeignKey
+ALTER TABLE "webhook_deliveries" ADD CONSTRAINT "webhook_deliveries_dead_letter_id_fkey" FOREIGN KEY ("dead_letter_id") REFERENCES "webhook_dead_letters"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "webhook_dead_letters" ADD CONSTRAINT "webhook_dead_letters_invoice_id_fkey" FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "webhook_dead_letters" ADD CONSTRAINT "webhook_dead_letters_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -46,8 +46,9 @@ model User {
   pushTokens     String[]  @default([]) @map("push_tokens")
   pushNotificationsEnabled Boolean @default(true) @map("push_notifications_enabled")
 
-  invoices       Invoice[]
-  webhooks       WebhookDelivery[]
+  invoices            Invoice[]
+  webhooks            WebhookDelivery[]
+  webhookDeadLetters  WebhookDeadLetter[]
 
   @@index([merchantId])
   @@map("users")
@@ -59,6 +60,8 @@ model WebhookDelivery {
   invoice        Invoice        @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
   userId         String         @map("user_id")
   user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deadLetterId   String?        @map("dead_letter_id")
+  deadLetter     WebhookDeadLetter? @relation(fields: [deadLetterId], references: [id], onDelete: SetNull)
   url            String
   payload        Json
   status         DeliveryStatus @default(pending)
@@ -71,10 +74,43 @@ model WebhookDelivery {
   @@map("webhook_deliveries")
 }
 
+model WebhookDeadLetter {
+  id               String           @id @default(uuid())
+  originalDeliveryId String         @unique @map("original_delivery_id")
+  invoiceId        String           @map("invoice_id")
+  invoice          Invoice          @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  userId           String           @map("user_id")
+  user             User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  merchantId       String           @map("merchant_id")
+  url              String
+  payload          Json
+  lastError        String?          @map("last_error")
+  lastHttpStatus   Int?             @map("last_http_status")
+  failedAttempts   Int              @map("failed_attempts")
+  exhaustedAt      DateTime         @default(now()) @map("exhausted_at")
+  manualRetryCount Int              @default(0) @map("manual_retry_count")
+  lastRetriedAt    DateTime?        @map("last_retried_at")
+  recoveredAt      DateTime?        @map("recovered_at")
+  status           DeadLetterStatus @default(pending_retry)
+  createdAt        DateTime         @default(now()) @map("created_at")
+  updatedAt        DateTime         @updatedAt @map("updated_at")
+  redriveDeliveries WebhookDelivery[]
+
+  @@index([merchantId])
+  @@index([status, exhaustedAt])
+  @@map("webhook_dead_letters")
+}
+
 enum DeliveryStatus {
   pending
   success
   failed
+}
+
+enum DeadLetterStatus {
+  pending_retry
+  requeued
+  recovered
 }
 
 // Invoice model matching backend/src/invoices/entities/invoice.entity.ts
@@ -105,9 +141,10 @@ model Invoice {
   createdAt          DateTime      @default(now()) @map("created_at")
   updatedAt          DateTime      @updatedAt @map("updated_at")
 
-  webhooks           WebhookDelivery[]
-  statusHistory      InvoiceStatusHistory[]
-  payments           Payment[]
+  webhooks              WebhookDelivery[]
+  webhookDeadLetters    WebhookDeadLetter[]
+  statusHistory         InvoiceStatusHistory[]
+  payments              Payment[]
 
   @@index([merchantId])
   @@map("invoices")

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { AuthController } from "./auth.controller";
 import { User } from "../users/user.entity";
 import { JwtStrategy } from "./strategy/jwt.strategy";
 import { JwtAuthGuard } from "./guard/auth.guard";
+import { AdminGuard } from "./guard/admin.guard";
 
 @Module({
   imports: [
@@ -24,8 +25,8 @@ import { JwtAuthGuard } from "./guard/auth.guard";
       }),
     }),
   ],
-  providers: [AuthService, JwtStrategy, JwtAuthGuard],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard, AdminGuard],
   controllers: [AuthController],
-  exports: [JwtAuthGuard, JwtModule],
+  exports: [JwtAuthGuard, AdminGuard, JwtModule],
 })
 export class AuthModule {}

--- a/backend/src/webhooks/admin-webhooks.controller.spec.ts
+++ b/backend/src/webhooks/admin-webhooks.controller.spec.ts
@@ -1,0 +1,67 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AdminWebhooksController } from "./admin-webhooks.controller";
+import { WebhooksService } from "./webhooks.service";
+
+describe("AdminWebhooksController", () => {
+  let controller: AdminWebhooksController;
+
+  const mockWebhooksService = {
+    listDeadLetters: jest.fn(),
+    getDeadLetter: jest.fn(),
+    retryDeadLetter: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminWebhooksController],
+      providers: [
+        { provide: WebhooksService, useValue: mockWebhooksService },
+      ],
+    }).compile();
+
+    controller = module.get<AdminWebhooksController>(AdminWebhooksController);
+  });
+
+  it("lists dead-letter jobs", async () => {
+    mockWebhooksService.listDeadLetters.mockResolvedValue([{ id: "dlq-1" }]);
+
+    const result = await controller.listDeadLetters({
+      status: "pending_retry" as any,
+      limit: 20,
+    });
+
+    expect(result).toEqual([{ id: "dlq-1" }]);
+    expect(mockWebhooksService.listDeadLetters).toHaveBeenCalledWith({
+      status: "pending_retry",
+      limit: 20,
+    });
+  });
+
+  it("returns a single dead-letter job", async () => {
+    mockWebhooksService.getDeadLetter.mockResolvedValue({ id: "dlq-2" });
+
+    const result = await controller.getDeadLetter("dlq-2");
+
+    expect(result).toEqual({ id: "dlq-2" });
+    expect(mockWebhooksService.getDeadLetter).toHaveBeenCalledWith("dlq-2");
+  });
+
+  it("queues a retry for a dead-letter job", async () => {
+    mockWebhooksService.retryDeadLetter.mockResolvedValue({
+      deadLetterId: "dlq-3",
+      deliveryId: "del-3",
+      status: "requeued",
+    });
+
+    const result = await controller.retryDeadLetter("dlq-3");
+
+    expect(result).toEqual({
+      deadLetterId: "dlq-3",
+      deliveryId: "del-3",
+      status: "requeued",
+    });
+    expect(mockWebhooksService.retryDeadLetter).toHaveBeenCalledWith("dlq-3");
+  });
+});

--- a/backend/src/webhooks/admin-webhooks.controller.ts
+++ b/backend/src/webhooks/admin-webhooks.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Param, Post, Query, UseGuards } from "@nestjs/common";
+import { AdminGuard } from "../auth/guard/admin.guard";
+import { WebhooksService } from "./webhooks.service";
+import { ListDeadLettersDto } from "./dto/list-dead-letters.dto";
+
+@Controller("admin/webhooks")
+@UseGuards(AdminGuard)
+export class AdminWebhooksController {
+  constructor(private readonly webhooksService: WebhooksService) {}
+
+  @Get("dead-letter")
+  async listDeadLetters(@Query() query: ListDeadLettersDto) {
+    return this.webhooksService.listDeadLetters(query);
+  }
+
+  @Get("dead-letter/:id")
+  async getDeadLetter(@Param("id") id: string) {
+    return this.webhooksService.getDeadLetter(id);
+  }
+
+  @Post("dead-letter/:id/retry")
+  async retryDeadLetter(@Param("id") id: string) {
+    return this.webhooksService.retryDeadLetter(id);
+  }
+}

--- a/backend/src/webhooks/dto/list-dead-letters.dto.ts
+++ b/backend/src/webhooks/dto/list-dead-letters.dto.ts
@@ -1,0 +1,16 @@
+import { DeadLetterStatus } from "@prisma/client";
+import { Type } from "class-transformer";
+import { IsEnum, IsInt, IsOptional, Max, Min } from "class-validator";
+
+export class ListDeadLettersDto {
+  @IsOptional()
+  @IsEnum(DeadLetterStatus)
+  status?: DeadLetterStatus;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/backend/src/webhooks/webhooks.module.ts
+++ b/backend/src/webhooks/webhooks.module.ts
@@ -3,10 +3,11 @@ import { PrismaModule } from "../prisma/prisma.module";
 import { AuthModule } from "../auth/auth.module";
 import { WebhooksController } from "./webhooks.controller";
 import { WebhooksService } from "./webhooks.service";
+import { AdminWebhooksController } from "./admin-webhooks.controller";
 
 @Module({
   imports: [PrismaModule, AuthModule],
-  controllers: [WebhooksController],
+  controllers: [WebhooksController, AdminWebhooksController],
   providers: [WebhooksService],
   exports: [WebhooksService],
 })

--- a/backend/src/webhooks/webhooks.service.spec.ts
+++ b/backend/src/webhooks/webhooks.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { WebhooksService } from "./webhooks.service";
 import { PrismaService } from "../prisma/prisma.service";
 import axios from "axios";
+import { BadRequestException } from "@nestjs/common";
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -9,7 +10,19 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe("WebhooksService", () => {
   let service: WebhooksService;
 
+  const mockTransactionClient = {
+    webhookDelivery: {
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+    webhookDeadLetter: {
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
   const mockPrismaService = {
+    $transaction: jest.fn(),
     user: {
       findUnique: jest.fn(),
       findFirst: jest.fn(),
@@ -21,12 +34,23 @@ describe("WebhooksService", () => {
     webhookDelivery: {
       create: jest.fn(),
       findMany: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    webhookDeadLetter: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
       update: jest.fn(),
     },
   };
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockPrismaService.$transaction.mockImplementation(async (callback: any) =>
+      callback(mockTransactionClient),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -127,10 +151,12 @@ describe("WebhooksService", () => {
       mockedAxios.post.mockResolvedValue({ status: 200 } as any);
       mockPrismaService.user.findUnique.mockResolvedValue({
         webhookSecret: "secret",
+        merchantId: "merchant-1",
       } as any);
 
       const delivery = {
         id: "del-1",
+        invoiceId: "inv-1",
         url: "https://example.com/webhook",
         payload: { status: "paid" },
         attempts: 0,
@@ -147,7 +173,7 @@ describe("WebhooksService", () => {
       expect(postArgs[2]?.headers?.["x-invoisio-signature"]).toBeDefined();
       expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({
         where: { id: "user-1" },
-        select: { webhookSecret: true },
+        select: { webhookSecret: true, merchantId: true },
       });
       expect(mockPrismaService.webhookDelivery.update).toHaveBeenCalledWith({
         where: { id: "del-1" },
@@ -162,10 +188,12 @@ describe("WebhooksService", () => {
       mockedAxios.post.mockRejectedValue(new Error("Timeout"));
       mockPrismaService.user.findUnique.mockResolvedValue({
         webhookSecret: null,
+        merchantId: "merchant-2",
       } as any);
 
       const delivery = {
         id: "del-2",
+        invoiceId: "inv-2",
         url: "https://example.com/webhook",
         payload: { status: "paid" },
         attempts: 1,
@@ -186,14 +214,16 @@ describe("WebhooksService", () => {
       expect(updateCall.data.nextAttemptAt).toBeInstanceOf(Date);
     });
 
-    it("should mark as failed permanently after 5 attempts", async () => {
+    it("moves exhausted deliveries into the dead-letter queue", async () => {
       mockedAxios.post.mockRejectedValue(new Error("Network Error"));
       mockPrismaService.user.findUnique.mockResolvedValue({
         webhookSecret: null,
+        merchantId: "merchant-9",
       } as any);
 
       const delivery = {
         id: "del-max",
+        invoiceId: "inv-max",
         url: "https://example.com/webhook",
         payload: { status: "paid" },
         attempts: 4,
@@ -203,13 +233,133 @@ describe("WebhooksService", () => {
 
       await service.deliver(delivery);
 
-      expect(mockPrismaService.webhookDelivery.update).toHaveBeenCalledWith({
+      expect(mockPrismaService.$transaction).toHaveBeenCalledTimes(1);
+      expect(mockTransactionClient.webhookDeadLetter.create).toHaveBeenCalledWith(
+        {
+          data: expect.objectContaining({
+            originalDeliveryId: "del-max",
+            invoiceId: "inv-max",
+            userId: "user-max",
+            merchantId: "merchant-9",
+            failedAttempts: 5,
+            status: "pending_retry",
+            lastError: "Network Error",
+          }),
+        },
+      );
+      expect(mockTransactionClient.webhookDelivery.delete).toHaveBeenCalledWith({
         where: { id: "del-max" },
+      });
+    });
+
+    it("marks dead-letter jobs as recovered when a manual retry succeeds", async () => {
+      mockedAxios.post.mockResolvedValue({ status: 200 } as any);
+      mockPrismaService.user.findUnique.mockResolvedValue({
+        webhookSecret: "secret",
+        merchantId: "merchant-1",
+      } as any);
+
+      const delivery = {
+        id: "del-redrive",
+        invoiceId: "inv-redrive",
+        url: "https://example.com/webhook",
+        payload: { status: "paid" },
+        attempts: 0,
+        userId: "user-1",
+        deadLetterId: "dlq-1",
+      };
+
+      await service.deliver(delivery);
+
+      expect(mockPrismaService.webhookDeadLetter.update).toHaveBeenCalledWith({
+        where: { id: "dlq-1" },
         data: expect.objectContaining({
-          status: "failed",
-          attempts: 5,
+          status: "recovered",
+          recoveredAt: expect.any(Date),
         }),
       });
+    });
+  });
+
+  describe("dead-letter admin tooling", () => {
+    it("lists dead-letter jobs with the provided filters", async () => {
+      const expected = [{ id: "dlq-1" }];
+      mockPrismaService.webhookDeadLetter.findMany.mockResolvedValue(
+        expected as any,
+      );
+
+      const result = await service.listDeadLetters({
+        status: "pending_retry" as any,
+        limit: 25,
+      });
+
+      expect(result).toBe(expected);
+      expect(mockPrismaService.webhookDeadLetter.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: "pending_retry" },
+          take: 25,
+        }),
+      );
+    });
+
+    it("queues a manual retry for a dead-letter job", async () => {
+      mockPrismaService.webhookDeadLetter.findUnique.mockResolvedValue({
+        id: "dlq-2",
+        invoiceId: "inv-2",
+        userId: "user-2",
+        url: "https://example.com/webhook",
+        payload: { status: "paid" },
+        status: "pending_retry",
+      } as any);
+      mockPrismaService.webhookDelivery.findFirst.mockResolvedValue(null as any);
+      mockTransactionClient.webhookDelivery.create.mockResolvedValue({
+        id: "del-retry",
+      } as any);
+
+      const result = await service.retryDeadLetter("dlq-2");
+
+      expect(result).toEqual({
+        deadLetterId: "dlq-2",
+        deliveryId: "del-retry",
+        status: "requeued",
+      });
+      expect(mockTransactionClient.webhookDelivery.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          invoiceId: "inv-2",
+          userId: "user-2",
+          deadLetterId: "dlq-2",
+          status: "pending",
+          attempts: 0,
+        }),
+      });
+      expect(mockTransactionClient.webhookDeadLetter.update).toHaveBeenCalledWith(
+        {
+          where: { id: "dlq-2" },
+          data: expect.objectContaining({
+            status: "requeued",
+            manualRetryCount: { increment: 1 },
+            lastRetriedAt: expect.any(Date),
+          }),
+        },
+      );
+    });
+
+    it("rejects duplicate manual retries while a retry is already pending", async () => {
+      mockPrismaService.webhookDeadLetter.findUnique.mockResolvedValue({
+        id: "dlq-3",
+        invoiceId: "inv-3",
+        userId: "user-3",
+        url: "https://example.com/webhook",
+        payload: { status: "paid" },
+        status: "pending_retry",
+      } as any);
+      mockPrismaService.webhookDelivery.findFirst.mockResolvedValue({
+        id: "del-existing",
+      } as any);
+
+      await expect(service.retryDeadLetter("dlq-3")).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
     });
   });
 });

--- a/backend/src/webhooks/webhooks.service.ts
+++ b/backend/src/webhooks/webhooks.service.ts
@@ -532,7 +532,7 @@ export class WebhooksService {
   }
 
   private toPrismaJsonValue(
-    value: Prisma.JsonValue,
+    value: unknown,
   ): Prisma.InputJsonValue | typeof Prisma.JsonNull {
     if (value === null) {
       return Prisma.JsonNull;

--- a/backend/src/webhooks/webhooks.service.ts
+++ b/backend/src/webhooks/webhooks.service.ts
@@ -1,8 +1,14 @@
-import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { PrismaService } from "../prisma/prisma.service";
 import axios from "axios";
 import * as crypto from "crypto";
+import { DeadLetterStatus, Prisma } from "@prisma/client";
 
 export interface WebhookSecretMetadata {
   hasSecret: boolean;
@@ -14,6 +20,15 @@ export interface WebhookSecretRotationResult {
   secret: string;
   metadata: WebhookSecretMetadata;
 }
+
+export interface DeadLetterListQuery {
+  status?: DeadLetterStatus;
+  limit?: number;
+}
+
+const MAX_DELIVERY_ATTEMPTS = 5;
+const DEFAULT_DEAD_LETTER_LIMIT = 50;
+const MAX_DEAD_LETTER_LIMIT = 100;
 
 @Injectable()
 export class WebhooksService {
@@ -167,7 +182,7 @@ export class WebhooksService {
     // effect immediately, even if this delivery was loaded before rotation.
     const user = await this.prisma.user.findUnique({
       where: { id: delivery.userId ?? delivery.user?.id },
-      select: { webhookSecret: true },
+      select: { webhookSecret: true, merchantId: true },
     });
     const secret = user?.webhookSecret;
     const payloadStr = JSON.stringify(delivery.payload);
@@ -203,24 +218,35 @@ export class WebhooksService {
         },
       });
 
+      if (delivery.deadLetterId) {
+        await this.prisma.webhookDeadLetter.update({
+          where: { id: delivery.deadLetterId },
+          data: {
+            status: "recovered",
+            recoveredAt: new Date(),
+          },
+        });
+      }
+
       this.logger.log(`Webhook delivery ${delivery.id} succeeded.`);
     } catch (error: any) {
       const attempts = delivery.attempts + 1;
+      const failure = this.toFailureDetails(error);
       this.logger.warn(
-        `Webhook delivery ${delivery.id} failed (attempt ${attempts}): ${error.message}`,
+        `Webhook delivery ${delivery.id} failed (attempt ${attempts}): ${failure.message}`,
       );
 
-      if (attempts >= 5) {
-        await this.prisma.webhookDelivery.update({
-          where: { id: delivery.id },
-          data: {
-            status: "failed",
-            lastAttemptAt: new Date(),
-            attempts,
+      if (attempts >= MAX_DELIVERY_ATTEMPTS) {
+        await this.moveToDeadLetter(
+          {
+            ...delivery,
+            merchantId: user?.merchantId,
           },
-        });
+          attempts,
+          failure,
+        );
         this.logger.error(
-          `Webhook delivery ${delivery.id} permanently failed after 5 attempts.`,
+          `Webhook delivery ${delivery.id} moved to dead-letter queue after ${MAX_DELIVERY_ATTEMPTS} attempts.`,
         );
       } else {
         // Exponential backoff: Math.pow(2, attempts) minutes
@@ -240,6 +266,140 @@ export class WebhooksService {
         });
       }
     }
+  }
+
+  async listDeadLetters(query: DeadLetterListQuery = {}) {
+    const take = this.normalizeDeadLetterLimit(query.limit);
+
+    return this.prisma.webhookDeadLetter.findMany({
+      where: query.status ? { status: query.status } : undefined,
+      take,
+      orderBy: [{ exhaustedAt: "desc" }, { createdAt: "desc" }],
+      include: {
+        invoice: {
+          select: {
+            id: true,
+            invoiceNumber: true,
+            status: true,
+            merchantId: true,
+          },
+        },
+        user: {
+          select: {
+            id: true,
+            email: true,
+            publicKey: true,
+          },
+        },
+      },
+    });
+  }
+
+  async getDeadLetter(deadLetterId: string) {
+    const deadLetter = await this.prisma.webhookDeadLetter.findUnique({
+      where: { id: deadLetterId },
+      include: {
+        invoice: {
+          select: {
+            id: true,
+            invoiceNumber: true,
+            status: true,
+            merchantId: true,
+          },
+        },
+        user: {
+          select: {
+            id: true,
+            email: true,
+            publicKey: true,
+          },
+        },
+        redriveDeliveries: {
+          orderBy: { createdAt: "desc" },
+          select: {
+            id: true,
+            status: true,
+            attempts: true,
+            lastAttemptAt: true,
+            nextAttemptAt: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        },
+      },
+    });
+
+    if (!deadLetter) {
+      throw new NotFoundException("Dead-letter webhook not found.");
+    }
+
+    return deadLetter;
+  }
+
+  async retryDeadLetter(deadLetterId: string) {
+    const deadLetter = await this.prisma.webhookDeadLetter.findUnique({
+      where: { id: deadLetterId },
+    });
+
+    if (!deadLetter) {
+      throw new NotFoundException("Dead-letter webhook not found.");
+    }
+
+    if (deadLetter.status === "recovered") {
+      throw new BadRequestException(
+        "Dead-letter webhook has already been recovered.",
+      );
+    }
+
+    const existingPendingRetry = await this.prisma.webhookDelivery.findFirst({
+      where: {
+        deadLetterId,
+        status: "pending",
+      },
+      select: { id: true },
+    });
+
+    if (existingPendingRetry) {
+      throw new BadRequestException(
+        "Dead-letter webhook is already queued for retry.",
+      );
+    }
+
+    const queuedAt = new Date();
+    const delivery = await this.prisma.$transaction(
+      async (tx: Prisma.TransactionClient) => {
+        const createdDelivery = await tx.webhookDelivery.create({
+          data: {
+            invoiceId: deadLetter.invoiceId,
+            userId: deadLetter.userId,
+            deadLetterId: deadLetter.id,
+            url: deadLetter.url,
+            payload: this.toPrismaJsonValue(deadLetter.payload),
+            status: "pending",
+            attempts: 0,
+            nextAttemptAt: queuedAt,
+          },
+        });
+
+        await tx.webhookDeadLetter.update({
+          where: { id: deadLetterId },
+          data: {
+            status: "requeued",
+            manualRetryCount: { increment: 1 },
+            lastRetriedAt: queuedAt,
+            recoveredAt: null,
+          },
+        });
+
+        return createdDelivery;
+      },
+    );
+
+    return {
+      deadLetterId: deadLetter.id,
+      deliveryId: delivery.id,
+      status: "requeued" as DeadLetterStatus,
+    };
   }
 
   private toSecretMetadata(secret: string | null): WebhookSecretMetadata {
@@ -268,5 +428,116 @@ export class WebhooksService {
     }
 
     return `${secret.slice(0, 4)}...${secret.slice(-4)}`;
+  }
+
+  private normalizeDeadLetterLimit(limit?: number): number {
+    if (!limit) {
+      return DEFAULT_DEAD_LETTER_LIMIT;
+    }
+
+    return Math.min(Math.max(limit, 1), MAX_DEAD_LETTER_LIMIT);
+  }
+
+  private toFailureDetails(error: any): {
+    message: string;
+    httpStatus: number | null;
+  } {
+    const httpStatus = error?.response?.status ?? null;
+    const responseData = error?.response?.data;
+
+    if (typeof responseData === "string" && responseData.trim().length > 0) {
+      return {
+        message: responseData.slice(0, 500),
+        httpStatus,
+      };
+    }
+
+    if (responseData && typeof responseData === "object") {
+      try {
+        return {
+          message: JSON.stringify(responseData).slice(0, 500),
+          httpStatus,
+        };
+      } catch {
+        // fall back to the generic message below
+      }
+    }
+
+    return {
+      message: error?.message ?? "Unknown webhook delivery error",
+      httpStatus,
+    };
+  }
+
+  private async moveToDeadLetter(
+    delivery: {
+      id: string;
+      invoiceId: string;
+      userId: string;
+      merchantId?: string | null;
+      deadLetterId?: string | null;
+      url: string;
+      payload: unknown;
+    },
+    attempts: number,
+    failure: { message: string; httpStatus: number | null },
+  ): Promise<void> {
+    const merchantId = delivery.merchantId;
+
+    if (!merchantId) {
+      throw new NotFoundException(
+        `Merchant not found for failed webhook delivery ${delivery.id}.`,
+      );
+    }
+
+    const exhaustedAt = new Date();
+
+    await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      if (delivery.deadLetterId) {
+        await tx.webhookDeadLetter.update({
+          where: { id: delivery.deadLetterId },
+          data: {
+            url: delivery.url,
+            payload: this.toPrismaJsonValue(delivery.payload),
+            lastError: failure.message,
+            lastHttpStatus: failure.httpStatus,
+            failedAttempts: attempts,
+            exhaustedAt,
+            status: "pending_retry",
+            recoveredAt: null,
+          },
+        });
+      } else {
+        await tx.webhookDeadLetter.create({
+          data: {
+            originalDeliveryId: delivery.id,
+            invoiceId: delivery.invoiceId,
+            userId: delivery.userId,
+            merchantId,
+            url: delivery.url,
+            payload: this.toPrismaJsonValue(delivery.payload),
+            lastError: failure.message,
+            lastHttpStatus: failure.httpStatus,
+            failedAttempts: attempts,
+            exhaustedAt,
+            status: "pending_retry",
+          },
+        });
+      }
+
+      await tx.webhookDelivery.delete({
+        where: { id: delivery.id },
+      });
+    });
+  }
+
+  private toPrismaJsonValue(
+    value: Prisma.JsonValue | unknown,
+  ): Prisma.InputJsonValue | typeof Prisma.JsonNull {
+    if (value === null) {
+      return Prisma.JsonNull;
+    }
+
+    return value as Prisma.InputJsonValue;
   }
 }

--- a/backend/src/webhooks/webhooks.service.ts
+++ b/backend/src/webhooks/webhooks.service.ts
@@ -532,7 +532,7 @@ export class WebhooksService {
   }
 
   private toPrismaJsonValue(
-    value: Prisma.JsonValue | unknown,
+    value: Prisma.JsonValue,
   ): Prisma.InputJsonValue | typeof Prisma.JsonNull {
     if (value === null) {
       return Prisma.JsonNull;


### PR DESCRIPTION
## Summary
- move exhausted webhook deliveries into a dedicated dead-letter table instead of leaving them in the active queue
- add admin endpoints to inspect dead-letter jobs and requeue them for manual recovery
- document the manual retry flow and add focused webhook tests

## Testing
- npm test -- --runTestsByPath src/webhooks/webhooks.service.spec.ts src/webhooks/admin-webhooks.controller.spec.ts src/webhooks/webhooks.controller.spec.ts

Closes #129