### PR TITLE
feat(auth): add logout and JWT session revocation

### DIFF
--- a/backend/prisma/migrations/20260716090000_add_user_token_version/migration.sql
+++ b/backend/prisma/migrations/20260716090000_add_user_token_version/migration.sql
@@ -1,0 +1,4 @@
+-- Add per-user token version to support JWT session revocation (logout).
+ALTER TABLE "users"
+ADD COLUMN "token_version" INTEGER NOT NULL DEFAULT 0;
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   nonce          String?
   nonceExpiresAt BigInt?   @map("nonce_expires_at")
   nonceUsedAt    DateTime? @map("nonce_used_at")
+  tokenVersion   Int       @default(0) @map("token_version")
   isAdmin        Boolean   @default(false) @map("is_admin")
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -50,4 +50,15 @@ export class AuthController {
       createdAt: user.createdAt,
     };
   }
+
+  /**
+   * POST /auth/logout
+   * Revokes the caller's active JWT session(s) by bumping tokenVersion.
+   */
+  @Auth()
+  @Post("logout")
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async logout(@CurrentUser() user: User) {
+    await this.authService.logout(user.id);
+  }
 }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -22,16 +22,18 @@ const mockPrisma = () => ({
 describe("AuthService", () => {
   let service: AuthService;
   let prisma: ReturnType<typeof mockPrisma>;
+  let jwtService: { sign: jest.Mock };
 
   const keypair = StellarSdk.Keypair.random();
   const publicKey = keypair.publicKey();
 
   beforeEach(async () => {
+    jwtService = { sign: jest.fn(() => "jwt-token") };
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
         { provide: PrismaService, useFactory: mockPrisma },
-        { provide: JwtService, useValue: { sign: jest.fn(() => "jwt-token") } },
+        { provide: JwtService, useValue: jwtService },
         {
           provide: StructuredLogger,
           useValue: mockStructuredLogger,
@@ -93,6 +95,7 @@ describe("AuthService", () => {
         publicKey,
         nonce,
         nonceExpiresAt: BigInt(Date.now() + 60_000),
+        tokenVersion: 0,
       });
       prisma.user.update.mockResolvedValue({});
 
@@ -101,6 +104,12 @@ describe("AuthService", () => {
         signedNonce: signature,
       });
       expect(result.accessToken).toBe("jwt-token");
+      expect(jwtService.sign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sub: "user-id",
+          tokenVersion: 0,
+        }),
+      );
     });
 
     it("throws when nonce is expired", async () => {
@@ -222,6 +231,22 @@ describe("AuthService", () => {
         data: Record<string, unknown>;
       };
       expect(updateArg.data.nonceUsedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("logout", () => {
+    it("increments the user's tokenVersion to revoke active tokens", async () => {
+      prisma.user.update.mockResolvedValue({});
+
+      await service.logout("user-id");
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: "user-id" },
+        data: expect.any(Object),
+      });
+
+      const call = prisma.user.update.mock.calls[0]?.[0];
+      expect(call.data).toEqual({ tokenVersion: { increment: 1 } });
     });
   });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -192,6 +192,7 @@ export class AuthService {
       sub: user.id,
       publicKey: user.publicKey,
       merchantId: user.merchantId,
+      tokenVersion: (user as any).tokenVersion ?? 0,
     };
     const accessToken = this.jwtService.sign(payload);
 
@@ -204,6 +205,23 @@ export class AuthService {
     });
 
     return { accessToken };
+  }
+
+  /**
+   * Invalidate active JWTs for the current user by bumping the token version.
+   * Any token minted with the previous version will fail validation.
+   */
+  async logout(userId: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { tokenVersion: { increment: 1 } } as any,
+    });
+
+    this.logger.info("auth.logout", {
+      domain: "auth",
+      event: "logout",
+      userId,
+    });
   }
 
   // ── Private helpers ──────────────────────────────────────────────────────────

--- a/backend/src/auth/strategy/jwt.strategy.spec.ts
+++ b/backend/src/auth/strategy/jwt.strategy.spec.ts
@@ -1,0 +1,114 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { JwtStrategy } from "./jwt.strategy";
+
+const mockPrisma = () => ({
+  user: {
+    findUnique: jest.fn(),
+  },
+});
+
+const mockConfigService = () => ({
+  getOrThrow: jest.fn(() => "test-secret-at-least-32-chars-0123456789"),
+});
+
+describe("JwtStrategy (token revocation)", () => {
+  it("accepts token when tokenVersion matches", async () => {
+    const prisma = mockPrisma();
+    prisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      merchantId: "merchant-1",
+      publicKey: "G....",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      email: null,
+      isAdmin: false,
+      tokenVersion: 2,
+    });
+
+    const strategy = new JwtStrategy(prisma as any, mockConfigService() as any);
+
+    const user = await strategy.validate({
+      sub: "user-1",
+      publicKey: "G....",
+      merchantId: "merchant-1",
+      tokenVersion: 2,
+    });
+
+    expect(user.id).toBe("user-1");
+    expect(user.tokenVersion).toBe(2);
+  });
+
+  it("rejects token when tokenVersion is stale", async () => {
+    const prisma = mockPrisma();
+    prisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      merchantId: "merchant-1",
+      publicKey: "G....",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      email: null,
+      isAdmin: false,
+      tokenVersion: 3,
+    });
+
+    const strategy = new JwtStrategy(prisma as any, mockConfigService() as any);
+
+    await expect(
+      strategy.validate({
+        sub: "user-1",
+        publicKey: "G....",
+        merchantId: "merchant-1",
+        tokenVersion: 2,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it("treats missing tokenVersion as 0 (backward compatible)", async () => {
+    const prisma = mockPrisma();
+    prisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      merchantId: "merchant-1",
+      publicKey: "G....",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      email: null,
+      isAdmin: false,
+      tokenVersion: 0,
+    });
+
+    const strategy = new JwtStrategy(prisma as any, mockConfigService() as any);
+
+    await expect(
+      strategy.validate({
+        sub: "user-1",
+        publicKey: "G....",
+        merchantId: "merchant-1",
+      } as any),
+    ).resolves.toBeTruthy();
+  });
+
+  it("rejects missing tokenVersion when user has logged out (tokenVersion > 0)", async () => {
+    const prisma = mockPrisma();
+    prisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      merchantId: "merchant-1",
+      publicKey: "G....",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      email: null,
+      isAdmin: false,
+      tokenVersion: 1,
+    });
+
+    const strategy = new JwtStrategy(prisma as any, mockConfigService() as any);
+
+    await expect(
+      strategy.validate({
+        sub: "user-1",
+        publicKey: "G....",
+        merchantId: "merchant-1",
+      } as any),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+});
+

--- a/backend/src/auth/strategy/jwt.strategy.ts
+++ b/backend/src/auth/strategy/jwt.strategy.ts
@@ -9,6 +9,7 @@ export interface JwtPayload {
   sub: string;
   publicKey: string;
   merchantId?: string;
+  tokenVersion?: number;
 }
 
 @Injectable()
@@ -31,6 +32,17 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!user) {
       throw new UnauthorizedException("User no longer exists.");
     }
+
+    // Session revocation:
+    // - tokens include `tokenVersion` in their payload
+    // - logout increments user's `tokenVersion`
+    // - any token with a stale version is rejected
+    const payloadVersion = payload.tokenVersion ?? 0;
+    const userVersion = (user as any).tokenVersion ?? 0;
+    if (payloadVersion !== userVersion) {
+      throw new UnauthorizedException("Token has been revoked.");
+    }
+
     return {
       id: user.id,
       merchantId: user.merchantId,
@@ -39,6 +51,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       updatedAt: user.updatedAt,
       email: user.email,
       isAdmin: user.isAdmin,
+      tokenVersion: (user as any).tokenVersion ?? 0,
     } as any;
   }
 }

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -11,6 +11,12 @@ export class User {
 
   nonceExpiresAt?: number | bigint | null;
 
+  /**
+   * JWT session version used for revocation.
+   * Incrementing this value invalidates previously issued tokens.
+   */
+  tokenVersion: number;
+
   isAdmin: boolean;
 
   createdAt?: Date;


### PR DESCRIPTION
Description: This PR adds a clean JWT session lifecycle so merchants can invalidate active tokens.

Changes

Adds POST /auth/logout (protected) which revokes the caller’s active session by bumping a per-user tokenVersion.
Adds tokenVersion to the User model (Prisma) + SQL migration.
Includes tokenVersion in newly issued JWTs.
Updates JWT validation to reject tokens whose tokenVersion no longer matches the user record.
Acceptance criteria

Logged-out tokens can no longer access protected routes (stale tokenVersion rejected).
Added tests covering logout + revocation behavior.
Notes

Revocation is per-user (logout invalidates all previously issued tokens for that user)