### PR TITLE
feat: add contributor bootstrap script for backend, web, mobile, and soroban

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,288 @@
+# Contributing to Invoisio
+
+Welcome! This guide gets you from a fresh clone to a running development environment in one command.
+
+## Quick bootstrap
+
+### Linux / macOS / WSL
+
+```bash
+./scripts/bootstrap.sh          # set up all workspaces
+./scripts/bootstrap.sh backend  # backend only
+./scripts/bootstrap.sh web      # web only
+./scripts/bootstrap.sh mobile   # mobile only
+./scripts/bootstrap.sh soroban  # soroban only
+```
+
+### Windows (PowerShell)
+
+```powershell
+.\scripts\bootstrap.ps1                    # set up all workspaces
+.\scripts\bootstrap.ps1 -Target backend   # backend only
+.\scripts\bootstrap.ps1 -Target web       # web only
+.\scripts\bootstrap.ps1 -Target mobile    # mobile only
+.\scripts\bootstrap.ps1 -Target soroban   # soroban only
+```
+
+> **Windows note:** The Soroban shell scripts (`build.sh`, `deploy.sh`) require
+> **WSL 2** or **Git Bash**. The bootstrap PowerShell script handles everything
+> else natively. See [Soroban setup](#soroban-rust-smart-contracts) for details.
+
+The script checks prerequisites, installs dependencies, copies environment
+files, and prints exactly what to do next. Errors fail with actionable messages.
+
+---
+
+## Prerequisites
+
+| Tool | Min version | Required by | Install |
+|------|-------------|-------------|---------|
+| **Node.js** | 18 | backend, web, mobile | [nodejs.org](https://nodejs.org/en/download) |
+| **npm** | 9 | backend, web, mobile | Bundled with Node.js |
+| **PostgreSQL** | 14 | backend | [postgresql.org](https://www.postgresql.org/download/) or Docker |
+| **Rust + Cargo** | stable | soroban | [rustup.rs](https://rustup.rs) / `winget install Rustlang.Rustup` |
+| **rustup** | — | soroban | Bundled with Rust |
+| **wasm32v1-none target** | — | soroban | Auto-installed by bootstrap |
+| **Stellar CLI** | ≥ 22 | soroban deploy | `cargo install --locked stellar-cli --features opt` |
+
+You do **not** need all prerequisites to work on a single workspace — only install what
+the workspace you're contributing to requires.
+
+---
+
+## Workspace setup
+
+### Backend (NestJS + Prisma + PostgreSQL)
+
+```bash
+# 1. Install dependencies + generate Prisma client
+cd backend
+npm install
+
+# 2. Configure environment
+cp .env.example .env
+# Edit .env — at minimum set DATABASE_URL
+
+# 3. Run database migrations
+npx prisma migrate dev
+
+# 4. Start the dev server (http://localhost:3001)
+npm run start:dev
+```
+
+Key environment variables in `backend/.env`:
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `JWT_SECRET` | Secret for signing JWTs |
+| `HORIZON_URL` | Stellar Horizon endpoint |
+| `STELLAR_NETWORK_PASSPHRASE` | Testnet or Mainnet passphrase |
+| `MERCHANT_PUBLIC_KEY` | Stellar G-address for receiving payments |
+| `SOROBAN_RPC_URL` | Soroban RPC endpoint |
+| `SOROBAN_CONTRACT_ID` | Deployed invoice-payment contract ID |
+| `ADMIN_SECRET_KEY` | Contract admin secret key (never commit a real key) |
+
+**Docker alternative for PostgreSQL:**
+
+```bash
+docker run -d \
+  --name invoisio-postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=invoisio_db \
+  -p 5432:5432 \
+  postgres:16
+```
+
+---
+
+### Web (Next.js 16)
+
+```bash
+cd web
+npm install
+npm run dev   # http://localhost:3000
+```
+
+No `.env` file is required for basic development. The web app talks to the
+backend at the URL configured in `web/lib/api-client.ts`.
+
+---
+
+### Mobile (Expo React Native)
+
+```bash
+cd mobile
+npm install
+
+# Configure environment (created by bootstrap, or manually):
+cp /dev/null mobile/.env   # creates empty file — fill in values below
+```
+
+Required variables in `mobile/.env`:
+
+| Variable | Description |
+|----------|-------------|
+| `API_URL` | Backend URL, e.g. `http://localhost:3001` |
+| `STELLAR_NETWORK_PASSPHRASE` | Network passphrase (testnet default) |
+| `REOWN_PROJECT_ID` | WalletConnect project ID from [cloud.reown.com](https://cloud.reown.com) |
+| `APP_NAME` | App display name (default: `Invoisio`) |
+
+```bash
+npx expo start   # start dev server + QR code
+```
+
+- **iOS simulator**: press `i`
+- **Android emulator**: press `a`
+- **Physical device**: scan QR code with [Expo Go](https://expo.dev/go)
+
+Smoke test checklist: [`mobile/SMOKE_TEST_CHECKLIST.md`](mobile/SMOKE_TEST_CHECKLIST.md)
+
+---
+
+### Soroban (Rust Smart Contracts)
+
+```bash
+# Install Rust (if not already installed)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+# Install the wasm32v1-none target (auto-installed by bootstrap)
+rustup target add wasm32v1-none
+
+# Install Stellar CLI
+cargo install --locked stellar-cli --features opt
+
+# Build the contract WASM
+cd soroban
+./build.sh
+
+# Run unit tests (no network required)
+cargo test
+
+# Deploy to Stellar testnet
+./deploy.sh
+```
+
+**Windows contributors:** Use **WSL 2** for the shell scripts.
+
+```powershell
+# Install WSL 2 (run as Administrator)
+wsl --install
+# Then open a WSL terminal and run the commands above
+```
+
+Full Soroban docs: [`soroban/README.md`](soroban/README.md)
+
+---
+
+## Development workflow
+
+### Running everything locally
+
+Start these in separate terminals:
+
+```bash
+# Terminal 1 — Backend API
+cd backend && npm run start:dev
+
+# Terminal 2 — Web frontend
+cd web && npm run dev
+
+# Terminal 3 — Mobile (optional)
+cd mobile && npx expo start
+```
+
+### Running tests
+
+```bash
+# Backend unit tests
+cd backend && npm test
+
+# Backend e2e tests (requires running PostgreSQL)
+cd backend && npm run test:e2e
+
+# Soroban unit tests (no network needed)
+cd soroban && cargo test
+```
+
+---
+
+## Git workflow
+
+1. Fork the repo and clone your fork
+2. Create a feature branch:
+   ```bash
+   git checkout -b feat/your-feature-name
+   ```
+3. Make your changes
+4. Run relevant tests before committing
+5. Commit using [Conventional Commits](https://www.conventionalcommits.org/):
+   ```
+   feat: add amazing feature
+   fix: correct invoice amount rounding
+   docs: update soroban deployment guide
+   chore: bump stellar-sdk to 14.7
+   ```
+6. Push and open a pull request against `main`
+
+---
+
+## Troubleshooting
+
+### `prisma generate` fails
+
+Make sure you are in the `backend/` directory and `DATABASE_URL` is set in `backend/.env`.
+
+### `wasm32v1-none` target not found
+
+Run `rustup target add wasm32v1-none`. The bootstrap script does this automatically.
+
+### Expo QR code not working
+
+Ensure your phone and computer are on the same Wi-Fi network. Alternatively use
+`npx expo start --tunnel` to route through Expo's servers.
+
+### PostgreSQL connection refused
+
+Check that the Postgres service is running:
+```bash
+# macOS (Homebrew)
+brew services start postgresql
+
+# Linux (systemd)
+sudo systemctl start postgresql
+
+# Docker
+docker start invoisio-postgres
+```
+
+### Stellar CLI not found after `cargo install`
+
+Make sure `~/.cargo/bin` is in your `PATH`:
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+# Add this line to ~/.bashrc or ~/.zshrc to persist it
+```
+
+---
+
+## Project structure
+
+```
+./
+├── backend/        NestJS API  (invoices, payments, Soroban integration)
+├── web/            Next.js 16 web app
+├── mobile/         Expo React Native app
+├── soroban/        Rust Soroban smart contracts
+├── scripts/        Developer tooling (bootstrap.sh, bootstrap.ps1)
+└── legacy/         Legacy code kept for reference (not actively developed)
+```
+
+---
+
+## Getting help
+
+- Open an issue with the `question` label
+- Check existing issues and pull requests before starting work on something new
+- For Stellar/Soroban questions: [Stellar Developer Discord](https://discord.gg/stellardev)

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,0 +1,410 @@
+# =============================================================================
+# Invoisio — Contributor Bootstrap Script (PowerShell)
+# =============================================================================
+# Sets up the full development environment for all active workspaces:
+#   backend  — NestJS + Prisma + PostgreSQL
+#   web      — Next.js 16
+#   mobile   — Expo React Native
+#   soroban  — Rust Soroban smart contracts
+#
+# Usage:
+#   .\scripts\bootstrap.ps1              # bootstrap all workspaces
+#   .\scripts\bootstrap.ps1 -Target backend   # backend only
+#   .\scripts\bootstrap.ps1 -Target web       # web only
+#   .\scripts\bootstrap.ps1 -Target mobile    # mobile only
+#   .\scripts\bootstrap.ps1 -Target soroban   # soroban only
+#
+# Requirements:
+#   Node.js 18+, npm, PostgreSQL 14+ (for backend), Rust + Cargo (for soroban)
+# =============================================================================
+
+[CmdletBinding()]
+param(
+    [ValidateSet("all","backend","web","mobile","soroban")]
+    [string]$Target = "all"
+)
+
+$ErrorActionPreference = "Stop"
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+function Write-Info    { param($Msg) Write-Host "  ℹ️  $Msg" -ForegroundColor Cyan }
+function Write-Success { param($Msg) Write-Host "  ✅  $Msg" -ForegroundColor Green }
+function Write-Warn    { param($Msg) Write-Host "  ⚠️  $Msg" -ForegroundColor Yellow }
+function Write-Err     { param($Msg) Write-Host "  ❌  $Msg" -ForegroundColor Red }
+function Write-Header  {
+    param($Msg)
+    Write-Host ""
+    Write-Host "══════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host "  $Msg" -ForegroundColor Cyan
+    Write-Host "══════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host ""
+}
+
+# ── Repo root ─────────────────────────────────────────────────────────────────
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+
+# =============================================================================
+# HELPER: Check if a command exists
+# =============================================================================
+function Test-Command {
+    param(
+        [string]$Name,
+        [string]$InstallHint = ""
+    )
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Write-Err "Required command not found: $Name"
+        if ($InstallHint) {
+            Write-Host "    Install hint: $InstallHint" -ForegroundColor Yellow
+        }
+        return $false
+    }
+    return $true
+}
+
+# =============================================================================
+# HELPER: Verify Node.js version >= 18
+# =============================================================================
+function Test-NodeVersion {
+    $verStr = (node --version 2>&1) -replace "v",""
+    $major  = [int]($verStr.Split(".")[0])
+    if ($major -lt 18) {
+        Write-Err "Node.js 18+ required. Current: v$verStr"
+        return $false
+    }
+    Write-Success "Node.js v$verStr"
+    return $true
+}
+
+# =============================================================================
+# HELPER: copy .env.example → .env if .env does not exist
+# =============================================================================
+function Copy-EnvFile {
+    param([string]$Dir)
+    $example = Join-Path $Dir ".env.example"
+    $target  = Join-Path $Dir ".env"
+
+    if (Test-Path $target) {
+        Write-Info ".env already exists in $(Split-Path -Leaf $Dir), skipping copy"
+        return
+    }
+    if (-not (Test-Path $example)) {
+        Write-Warn "No .env.example found in $(Split-Path -Leaf $Dir)"
+        return
+    }
+    Copy-Item $example $target
+    Write-Success "Copied .env.example → .env in $(Split-Path -Leaf $Dir)"
+    Write-Warn "Review $target and fill in any blank values before running the app"
+}
+
+# =============================================================================
+# HELPER: create mobile .env if it doesn't exist
+# =============================================================================
+function New-MobileEnv {
+    $target = Join-Path $RepoRoot "mobile\.env"
+    if (Test-Path $target) {
+        Write-Info ".env already exists in mobile, skipping creation"
+        return
+    }
+
+    $content = @"
+# Mobile app environment variables
+# Fill in the values below before running the app
+
+# Backend API URL (e.g. http://localhost:3001 for local dev)
+API_URL=http://localhost:3001
+
+# Stellar network passphrase
+# Testnet: "Test SDF Network ; September 2015"
+# Mainnet: "Public Global Stellar Network ; September 2015"
+STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Reown (WalletConnect) project ID — get yours at https://cloud.reown.com
+REOWN_PROJECT_ID=your_reown_project_id_here
+
+# App display name
+APP_NAME=Invoisio
+"@
+    Set-Content -Path $target -Value $content -Encoding UTF8
+    Write-Success "Created mobile\.env with required variables"
+    Write-Warn "Edit mobile\.env and set API_URL and REOWN_PROJECT_ID before running the app"
+}
+
+# =============================================================================
+# WORKSPACE: backend
+# =============================================================================
+function Invoke-BackendBootstrap {
+    Write-Header "Backend (NestJS + Prisma + PostgreSQL)"
+    $dir    = Join-Path $RepoRoot "backend"
+    $failed = $false
+
+    # ── Prerequisites ──────────────────────────────────────────────────────
+    Write-Info "Checking prerequisites..."
+
+    if (-not (Test-Command "node" "https://nodejs.org/en/download  (Node.js 18+)")) { $failed = $true }
+    if (-not (Test-Command "npm"  "Comes with Node.js"))                            { $failed = $true }
+
+    if ((Get-Command "node" -ErrorAction SilentlyContinue) -and -not $failed) {
+        if (-not (Test-NodeVersion)) { $failed = $true }
+    }
+
+    # PostgreSQL — non-fatal
+    if (Get-Command "psql" -ErrorAction SilentlyContinue) {
+        $psqlVer = (psql --version 2>&1)
+        Write-Success "PostgreSQL client: $psqlVer"
+    } else {
+        Write-Warn "psql not found — make sure PostgreSQL is accessible (local or Docker)"
+        Write-Warn "Docker alternative: docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16"
+    }
+
+    if ($failed) {
+        Write-Err "Backend prerequisites not met. Fix the issues above and re-run."
+        return $false
+    }
+
+    # ── Environment ────────────────────────────────────────────────────────
+    Write-Info "Setting up environment..."
+    Copy-EnvFile $dir
+
+    # ── Install dependencies ───────────────────────────────────────────────
+    Write-Info "Installing npm dependencies..."
+    Push-Location $dir
+    try {
+        npm install
+        if ($LASTEXITCODE -ne 0) { throw "npm install failed" }
+        Write-Success "npm install complete"
+
+        # ── Prisma generate ────────────────────────────────────────────────
+        Write-Info "Generating Prisma client..."
+        npx prisma generate
+        if ($LASTEXITCODE -ne 0) { throw "prisma generate failed" }
+        Write-Success "Prisma client generated"
+    } finally {
+        Pop-Location
+    }
+
+    # ── Summary ────────────────────────────────────────────────────────────
+    Write-Host ""
+    Write-Success "Backend ready!"
+    Write-Host "  Next steps:" -ForegroundColor White
+    Write-Host "    1. Ensure PostgreSQL is running and backend\.env DATABASE_URL is correct"
+    Write-Host "    2. cd backend; npx prisma migrate dev    # apply DB migrations"
+    Write-Host "    3. cd backend; npm run start:dev          # start dev server on :3001"
+    Write-Host ""
+    return $true
+}
+
+# =============================================================================
+# WORKSPACE: web
+# =============================================================================
+function Invoke-WebBootstrap {
+    Write-Header "Web (Next.js 16)"
+    $dir    = Join-Path $RepoRoot "web"
+    $failed = $false
+
+    Write-Info "Checking prerequisites..."
+    if (-not (Test-Command "node" "https://nodejs.org/en/download  (Node.js 18+)")) { $failed = $true }
+    if (-not (Test-Command "npm"  "Comes with Node.js"))                            { $failed = $true }
+
+    if ((Get-Command "node" -ErrorAction SilentlyContinue) -and -not $failed) {
+        if (-not (Test-NodeVersion)) { $failed = $true }
+    }
+
+    if ($failed) {
+        Write-Err "Web prerequisites not met. Fix the issues above and re-run."
+        return $false
+    }
+
+    Write-Info "Installing npm dependencies..."
+    Push-Location $dir
+    try {
+        npm install
+        if ($LASTEXITCODE -ne 0) { throw "npm install failed" }
+        Write-Success "npm install complete"
+    } finally {
+        Pop-Location
+    }
+
+    Write-Host ""
+    Write-Success "Web ready!"
+    Write-Host "  Next steps:" -ForegroundColor White
+    Write-Host "    1. cd web; npm run dev    # start dev server on http://localhost:3000"
+    Write-Host ""
+    return $true
+}
+
+# =============================================================================
+# WORKSPACE: mobile
+# =============================================================================
+function Invoke-MobileBootstrap {
+    Write-Header "Mobile (Expo React Native)"
+    $dir    = Join-Path $RepoRoot "mobile"
+    $failed = $false
+
+    Write-Info "Checking prerequisites..."
+    if (-not (Test-Command "node" "https://nodejs.org/en/download  (Node.js 18+)")) { $failed = $true }
+    if (-not (Test-Command "npm"  "Comes with Node.js"))                            { $failed = $true }
+
+    if ((Get-Command "node" -ErrorAction SilentlyContinue) -and -not $failed) {
+        if (-not (Test-NodeVersion)) { $failed = $true }
+    }
+
+    if ($failed) {
+        Write-Err "Mobile prerequisites not met. Fix the issues above and re-run."
+        return $false
+    }
+
+    Write-Info "Setting up environment..."
+    New-MobileEnv
+
+    Write-Info "Installing npm dependencies..."
+    Push-Location $dir
+    try {
+        npm install
+        if ($LASTEXITCODE -ne 0) { throw "npm install failed" }
+        Write-Success "npm install complete"
+    } finally {
+        Pop-Location
+    }
+
+    # Expo CLI check
+    if (-not (Get-Command "expo" -ErrorAction SilentlyContinue)) {
+        Write-Warn "Expo CLI not found globally — you can still use 'npx expo'"
+        Write-Info "To install globally: npm install -g expo-cli"
+    } else {
+        Write-Success "Expo CLI available"
+    }
+
+    Write-Host ""
+    Write-Success "Mobile ready!"
+    Write-Host "  Next steps:" -ForegroundColor White
+    Write-Host "    1. Edit mobile\.env — set API_URL and REOWN_PROJECT_ID"
+    Write-Host "    2. cd mobile; npx expo start    # start Expo dev server"
+    Write-Host "    3. Scan the QR code with Expo Go (iOS/Android)"
+    Write-Host "       or press 'a' for Android emulator / 'i' for iOS simulator"
+    Write-Host ""
+    return $true
+}
+
+# =============================================================================
+# WORKSPACE: soroban
+# =============================================================================
+function Invoke-SorobanBootstrap {
+    Write-Header "Soroban (Rust Smart Contracts)"
+    $dir    = Join-Path $RepoRoot "soroban"
+    $failed = $false
+
+    Write-Info "Checking prerequisites..."
+
+    # Rust toolchain
+    if (-not (Test-Command "rustc" "https://rustup.rs  — run: winget install Rustlang.Rustup")) { $failed = $true }
+    if (-not (Test-Command "cargo" "Comes with Rust — see above"))                               { $failed = $true }
+    if (-not (Test-Command "rustup" "Comes with Rust — see above"))                              { $failed = $true }
+
+    if ($failed) {
+        Write-Err "Rust toolchain not found. Install it first, then re-run."
+        Write-Host ""
+        Write-Host "  Windows (recommended):" -ForegroundColor Yellow
+        Write-Host "    winget install Rustlang.Rustup" -ForegroundColor Yellow
+        Write-Host "  or download the installer from https://rustup.rs" -ForegroundColor Yellow
+        return $false
+    }
+
+    $rustVer  = (rustc --version 2>&1)
+    $cargoVer = (cargo --version 2>&1)
+    Write-Success "Rust:  $rustVer"
+    Write-Success "Cargo: $cargoVer"
+
+    # wasm32v1-none target
+    Write-Info "Checking wasm32v1-none target..."
+    $installedTargets = (rustup target list --installed 2>&1)
+    if ($installedTargets -match "wasm32v1-none") {
+        Write-Success "wasm32v1-none target already installed"
+    } else {
+        Write-Info "Installing wasm32v1-none target..."
+        rustup target add wasm32v1-none
+        if ($LASTEXITCODE -ne 0) { throw "Failed to add wasm32v1-none target" }
+        Write-Success "wasm32v1-none target installed"
+    }
+
+    # Stellar CLI
+    Write-Info "Checking Stellar CLI..."
+    if (Get-Command "stellar" -ErrorAction SilentlyContinue) {
+        $stellarVer = (stellar --version 2>&1 | Select-Object -First 1)
+        Write-Success "Stellar CLI: $stellarVer"
+    } else {
+        Write-Warn "Stellar CLI not found — required to build, deploy, and invoke contracts"
+        Write-Host ""
+        Write-Host "  Install Stellar CLI:" -ForegroundColor Yellow
+        Write-Host "    cargo install --locked stellar-cli --features opt" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Warn "Skipping Stellar CLI install (run the command above manually)"
+        Write-Warn "You can still compile and test locally without it using 'cargo build' / 'cargo test'"
+    }
+
+    # cargo check
+    Write-Info "Verifying contract compiles (cargo check)..."
+    Push-Location $dir
+    try {
+        cargo check --quiet
+        if ($LASTEXITCODE -ne 0) { throw "cargo check failed" }
+        Write-Success "Contract compiles successfully"
+    } finally {
+        Pop-Location
+    }
+
+    Write-Host ""
+    Write-Success "Soroban ready!"
+    Write-Host "  Next steps:" -ForegroundColor White
+    Write-Host "    1. cd soroban; .\build.sh       # compile to WASM  (use WSL or Git Bash on Windows)"
+    Write-Host "    2. cd soroban; cargo test        # run unit tests (no network needed)"
+    Write-Host "    3. cd soroban; .\deploy.sh       # deploy to Stellar testnet  (WSL/Git Bash)"
+    Write-Host ""
+    Write-Host "  Note: The .sh shell scripts require WSL 2 or Git Bash on Windows." -ForegroundColor Cyan
+    Write-Host "        Full docs: soroban\README.md" -ForegroundColor Cyan
+    Write-Host ""
+    return $true
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+Write-Host ""
+Write-Host "🧾 Invoisio — Contributor Bootstrap" -ForegroundColor Cyan -NoNewline
+Write-Host "  (Target: $Target)" -ForegroundColor White
+Write-Host ""
+
+$overallFailed = $false
+
+function Invoke-Workspace {
+    param([string]$Name)
+    $fn = "Invoke-$([System.Globalization.CultureInfo]::CurrentCulture.TextInfo.ToTitleCase($Name))Bootstrap"
+    $result = & $fn
+    if (-not $result) { $script:overallFailed = $true }
+}
+
+switch ($Target) {
+    "all" {
+        Invoke-Workspace "Backend"
+        Invoke-Workspace "Web"
+        Invoke-Workspace "Mobile"
+        Invoke-Workspace "Soroban"
+    }
+    default {
+        $titleName = [System.Globalization.CultureInfo]::CurrentCulture.TextInfo.ToTitleCase($Target)
+        Invoke-Workspace $titleName
+    }
+}
+
+Write-Host ""
+if (-not $overallFailed) {
+    Write-Host "🎉 Bootstrap complete! Happy hacking." -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Docs & guides:" -ForegroundColor Cyan
+    Write-Host "  CONTRIBUTING.md                    — contribution guide"
+    Write-Host "  backend\README.md                  — backend setup details"
+    Write-Host "  soroban\README.md                  — Soroban build/deploy/invoke"
+    Write-Host "  mobile\SMOKE_TEST_CHECKLIST.md     — mobile smoke tests"
+} else {
+    Write-Err "Bootstrap finished with errors. Fix the issues above and re-run."
+    exit 1
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Invoisio — Contributor Bootstrap Script
+# =============================================================================
+# Sets up the full development environment for all active workspaces:
+#   backend  — NestJS + Prisma + PostgreSQL
+#   web      — Next.js 16
+#   mobile   — Expo React Native
+#   soroban  — Rust Soroban smart contracts
+#
+# Usage:
+#   ./scripts/bootstrap.sh              # bootstrap all workspaces
+#   ./scripts/bootstrap.sh backend      # bootstrap backend only
+#   ./scripts/bootstrap.sh web          # bootstrap web only
+#   ./scripts/bootstrap.sh mobile       # bootstrap mobile only
+#   ./scripts/bootstrap.sh soroban      # bootstrap soroban only
+#
+# Requirements:
+#   Node.js 18+, npm, PostgreSQL 14+ (for backend), Rust + Cargo (for soroban)
+# =============================================================================
+
+set -euo pipefail
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()    { echo -e "${CYAN}ℹ️  ${1}${RESET}"; }
+success() { echo -e "${GREEN}✅ ${1}${RESET}"; }
+warn()    { echo -e "${YELLOW}⚠️  ${1}${RESET}"; }
+error()   { echo -e "${RED}❌ ${1}${RESET}" >&2; }
+header()  { echo -e "\n${BOLD}${CYAN}══════════════════════════════════════════${RESET}"; \
+            echo -e "${BOLD}${CYAN}  ${1}${RESET}"; \
+            echo -e "${BOLD}${CYAN}══════════════════════════════════════════${RESET}\n"; }
+
+# ── Repo root ─────────────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Target selection ──────────────────────────────────────────────────────────
+TARGET="${1:-all}"
+case "$TARGET" in
+  all|backend|web|mobile|soroban) ;;
+  *)
+    error "Unknown target: '$TARGET'"
+    echo "Usage: $0 [all|backend|web|mobile|soroban]"
+    exit 1
+    ;;
+esac
+
+# =============================================================================
+# HELPER: require a command to exist
+# =============================================================================
+require_cmd() {
+  local cmd="$1"
+  local install_hint="${2:-}"
+  if ! command -v "$cmd" &>/dev/null; then
+    error "Required command not found: $cmd"
+    if [[ -n "$install_hint" ]]; then
+      echo -e "  Install hint: ${YELLOW}${install_hint}${RESET}"
+    fi
+    return 1
+  fi
+  return 0
+}
+
+# =============================================================================
+# HELPER: copy .env.example → .env if .env does not exist
+# =============================================================================
+copy_env() {
+  local dir="$1"
+  local example="${dir}/.env.example"
+  local target="${dir}/.env"
+
+  if [[ -f "$target" ]]; then
+    info ".env already exists in $(basename "$dir"), skipping copy"
+    return 0
+  fi
+
+  if [[ ! -f "$example" ]]; then
+    warn "No .env.example found in $(basename "$dir")"
+    return 0
+  fi
+
+  cp "$example" "$target"
+  success "Copied .env.example → .env in $(basename "$dir")"
+  warn "Review ${target} and fill in any blank values before running the app"
+}
+
+# =============================================================================
+# HELPER: create mobile .env if it doesn't exist
+# =============================================================================
+create_mobile_env() {
+  local target="${REPO_ROOT}/mobile/.env"
+
+  if [[ -f "$target" ]]; then
+    info ".env already exists in mobile, skipping creation"
+    return 0
+  fi
+
+  cat > "$target" <<'EOF'
+# Mobile app environment variables
+# Fill in the values below before running the app
+
+# Backend API URL (e.g. http://localhost:3001 for local dev)
+API_URL=http://localhost:3001
+
+# Stellar network passphrase
+# Testnet: "Test SDF Network ; September 2015"
+# Mainnet: "Public Global Stellar Network ; September 2015"
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
+# Reown (WalletConnect) project ID — get yours at https://cloud.reown.com
+REOWN_PROJECT_ID=your_reown_project_id_here
+
+# App display name
+APP_NAME=Invoisio
+EOF
+
+  success "Created mobile/.env with required variables"
+  warn "Edit mobile/.env and set API_URL and REOWN_PROJECT_ID before running the app"
+}
+
+# =============================================================================
+# WORKSPACE: backend
+# =============================================================================
+bootstrap_backend() {
+  header "Backend (NestJS + Prisma + PostgreSQL)"
+
+  local dir="${REPO_ROOT}/backend"
+  local failed=0
+
+  # ── Prerequisites ──────────────────────────────────────────────────────────
+  info "Checking prerequisites..."
+
+  require_cmd node "https://nodejs.org/en/download  (Node.js 18+)" || failed=1
+  require_cmd npm  "Comes with Node.js" || failed=1
+
+  if command -v node &>/dev/null; then
+    local node_ver
+    node_ver=$(node -e "process.exit(parseInt(process.version.slice(1)) < 18 ? 1 : 0)" 2>&1 || echo "old")
+    if [[ "$node_ver" == "old" ]] || ! node -e "process.exit(parseInt(process.version.slice(1)) < 18 ? 1 : 0)" &>/dev/null; then
+      error "Node.js 18+ required. Current: $(node --version)"
+      failed=1
+    else
+      success "Node.js $(node --version)"
+    fi
+  fi
+
+  # PostgreSQL check (non-fatal — Docker is a valid alternative)
+  if command -v psql &>/dev/null; then
+    success "PostgreSQL client: $(psql --version | head -n1)"
+  else
+    warn "psql not found — make sure PostgreSQL is accessible (local or Docker)"
+    warn "Docker alternative: docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16"
+  fi
+
+  if [[ "$failed" -eq 1 ]]; then
+    error "Backend prerequisites not met. Fix the issues above and re-run."
+    return 1
+  fi
+
+  # ── Environment ────────────────────────────────────────────────────────────
+  info "Setting up environment..."
+  copy_env "$dir"
+
+  # ── Install dependencies ───────────────────────────────────────────────────
+  info "Installing npm dependencies..."
+  npm install --prefix "$dir"
+  success "npm install complete"
+
+  # ── Prisma generate ────────────────────────────────────────────────────────
+  info "Generating Prisma client..."
+  (cd "$dir" && npx prisma generate)
+  success "Prisma client generated"
+
+  # ── Summary ────────────────────────────────────────────────────────────────
+  echo ""
+  success "Backend ready!"
+  echo -e "${BOLD}Next steps:${RESET}"
+  echo "  1. Ensure PostgreSQL is running and backend/.env DATABASE_URL is correct"
+  echo "  2. cd backend && npx prisma migrate dev    # apply DB migrations"
+  echo "  3. cd backend && npm run start:dev          # start dev server on :3001"
+  echo ""
+}
+
+# =============================================================================
+# WORKSPACE: web
+# =============================================================================
+bootstrap_web() {
+  header "Web (Next.js 16)"
+
+  local dir="${REPO_ROOT}/web"
+  local failed=0
+
+  # ── Prerequisites ──────────────────────────────────────────────────────────
+  info "Checking prerequisites..."
+
+  require_cmd node "https://nodejs.org/en/download  (Node.js 18+)" || failed=1
+  require_cmd npm  "Comes with Node.js" || failed=1
+
+  if command -v node &>/dev/null; then
+    if ! node -e "process.exit(parseInt(process.version.slice(1)) < 18 ? 1 : 0)" &>/dev/null; then
+      error "Node.js 18+ required. Current: $(node --version)"
+      failed=1
+    else
+      success "Node.js $(node --version)"
+    fi
+  fi
+
+  if [[ "$failed" -eq 1 ]]; then
+    error "Web prerequisites not met. Fix the issues above and re-run."
+    return 1
+  fi
+
+  # ── Install dependencies ───────────────────────────────────────────────────
+  info "Installing npm dependencies..."
+  npm install --prefix "$dir"
+  success "npm install complete"
+
+  # ── Summary ────────────────────────────────────────────────────────────────
+  echo ""
+  success "Web ready!"
+  echo -e "${BOLD}Next steps:${RESET}"
+  echo "  1. cd web && npm run dev    # start dev server on http://localhost:3000"
+  echo ""
+}
+
+# =============================================================================
+# WORKSPACE: mobile
+# =============================================================================
+bootstrap_mobile() {
+  header "Mobile (Expo React Native)"
+
+  local dir="${REPO_ROOT}/mobile"
+  local failed=0
+
+  # ── Prerequisites ──────────────────────────────────────────────────────────
+  info "Checking prerequisites..."
+
+  require_cmd node "https://nodejs.org/en/download  (Node.js 18+)" || failed=1
+  require_cmd npm  "Comes with Node.js" || failed=1
+
+  if command -v node &>/dev/null; then
+    if ! node -e "process.exit(parseInt(process.version.slice(1)) < 18 ? 1 : 0)" &>/dev/null; then
+      error "Node.js 18+ required. Current: $(node --version)"
+      failed=1
+    else
+      success "Node.js $(node --version)"
+    fi
+  fi
+
+  if [[ "$failed" -eq 1 ]]; then
+    error "Mobile prerequisites not met. Fix the issues above and re-run."
+    return 1
+  fi
+
+  # ── Environment ────────────────────────────────────────────────────────────
+  info "Setting up environment..."
+  create_mobile_env
+
+  # ── Install dependencies ───────────────────────────────────────────────────
+  info "Installing npm dependencies..."
+  npm install --prefix "$dir"
+  success "npm install complete"
+
+  # ── Check Expo CLI ─────────────────────────────────────────────────────────
+  if ! command -v expo &>/dev/null && ! npx expo --version &>/dev/null 2>&1; then
+    warn "Expo CLI not found globally — you can still use 'npx expo'"
+    info "To install globally: npm install -g expo-cli"
+  else
+    success "Expo CLI available"
+  fi
+
+  # ── Summary ────────────────────────────────────────────────────────────────
+  echo ""
+  success "Mobile ready!"
+  echo -e "${BOLD}Next steps:${RESET}"
+  echo "  1. Edit mobile/.env — set API_URL and REOWN_PROJECT_ID"
+  echo "  2. cd mobile && npx expo start    # start Expo dev server"
+  echo "  3. Scan the QR code with Expo Go app (iOS/Android)"
+  echo "     or press 'a' for Android emulator / 'i' for iOS simulator"
+  echo ""
+}
+
+# =============================================================================
+# WORKSPACE: soroban
+# =============================================================================
+bootstrap_soroban() {
+  header "Soroban (Rust Smart Contracts)"
+
+  local dir="${REPO_ROOT}/soroban"
+  local failed=0
+
+  # ── Prerequisites ──────────────────────────────────────────────────────────
+  info "Checking prerequisites..."
+
+  # Rust
+  if require_cmd rustc "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"; then
+    success "Rust: $(rustc --version)"
+  else
+    failed=1
+  fi
+
+  if require_cmd cargo "Comes with Rust — see above" ; then
+    success "Cargo: $(cargo --version)"
+  else
+    failed=1
+  fi
+
+  if require_cmd rustup "Comes with Rust — see above"; then
+    success "rustup: $(rustup --version 2>&1 | head -n1)"
+  else
+    failed=1
+  fi
+
+  if [[ "$failed" -eq 1 ]]; then
+    error "Rust toolchain not found. Install it first, then re-run."
+    echo ""
+    echo -e "  ${YELLOW}curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh${RESET}"
+    echo -e "  ${YELLOW}source \"\$HOME/.cargo/env\"${RESET}"
+    return 1
+  fi
+
+  # wasm32v1-none target
+  info "Checking wasm32v1-none target..."
+  if rustup target list --installed 2>/dev/null | grep -q "wasm32v1-none"; then
+    success "wasm32v1-none target already installed"
+  else
+    info "Installing wasm32v1-none target..."
+    rustup target add wasm32v1-none
+    success "wasm32v1-none target installed"
+  fi
+
+  # Stellar CLI
+  info "Checking Stellar CLI..."
+  if command -v stellar &>/dev/null; then
+    success "Stellar CLI: $(stellar --version | head -n1)"
+  else
+    warn "Stellar CLI not found — required to build, deploy, and invoke contracts"
+    echo ""
+    echo -e "  Install Stellar CLI:"
+    echo -e "  ${YELLOW}cargo install --locked stellar-cli --features opt${RESET}"
+    echo ""
+    warn "Skipping Stellar CLI install (run the command above manually)"
+    warn "You can still compile and test locally without it using 'cargo build' and 'cargo test'"
+  fi
+
+  # ── Verify contract compiles ───────────────────────────────────────────────
+  info "Verifying contract compiles (cargo check)..."
+  if (cd "$dir" && cargo check --quiet 2>&1); then
+    success "Contract compiles successfully"
+  else
+    error "cargo check failed — see output above"
+    return 1
+  fi
+
+  # ── Summary ────────────────────────────────────────────────────────────────
+  echo ""
+  success "Soroban ready!"
+  echo -e "${BOLD}Next steps:${RESET}"
+  echo "  1. cd soroban && ./build.sh          # compile to WASM"
+  echo "  2. cd soroban && cargo test           # run unit tests (no network)"
+  echo "  3. cd soroban && ./deploy.sh          # deploy to Stellar testnet"
+  echo ""
+  echo -e "  ${CYAN}Full docs: soroban/README.md${RESET}"
+  echo ""
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+main() {
+  echo ""
+  echo -e "${BOLD}${CYAN}🧾 Invoisio — Contributor Bootstrap${RESET}"
+  echo -e "${CYAN}   Target: ${BOLD}${TARGET}${RESET}"
+  echo ""
+
+  local overall_failed=0
+
+  run_workspace() {
+    local ws="$1"
+    local fn="bootstrap_${ws}"
+    if ! "$fn"; then
+      overall_failed=1
+      error "${ws} bootstrap failed"
+    fi
+  }
+
+  case "$TARGET" in
+    all)
+      run_workspace backend
+      run_workspace web
+      run_workspace mobile
+      run_workspace soroban
+      ;;
+    *)
+      run_workspace "$TARGET"
+      ;;
+  esac
+
+  echo ""
+  if [[ "$overall_failed" -eq 0 ]]; then
+    echo -e "${BOLD}${GREEN}🎉 Bootstrap complete! Happy hacking.${RESET}"
+    echo ""
+    echo -e "${CYAN}Docs & guides:${RESET}"
+    echo "  CONTRIBUTING.md       — contribution guide"
+    echo "  backend/README.md     — backend setup details"
+    echo "  soroban/README.md     — Soroban build/deploy/invoke"
+    echo "  mobile/SMOKE_TEST_CHECKLIST.md — mobile smoke tests"
+  else
+    echo -e "${BOLD}${RED}Bootstrap finished with errors. Fix the issues above and re-run.${RESET}"
+    exit 1
+  fi
+}
+
+main


### PR DESCRIPTION
## Summary

Closes #237

Adds a one-command contributor bootstrap that prepares all four active workspaces — backend, web, mobile, and soroban — with a single script run.

## Changes

| File | Description |
|------|-------------|
| `scripts/bootstrap.sh` | Bash script for Linux / macOS / WSL contributors |
| `scripts/bootstrap.ps1` | PowerShell script for Windows-first contributors |
| `CONTRIBUTING.md` | Full contributor guide with per-workspace setup docs |

## What the scripts do

- ✅ Check required prerequisites (Node.js 18+, Rust, Stellar CLI, wasm32v1-none target)
- ✅ Copy `.env.example → .env` (backend) or create `mobile/.env` from template
- ✅ Run `npm install` for backend, web, and mobile
- ✅ Generate the Prisma client after backend install
- ✅ Install the `wasm32v1-none` Rust target for Soroban
- ✅ Print actionable next-step instructions per workspace
- ✅ Exit with a clear, descriptive error on any failure

## Usage

```bash
# Linux / macOS / WSL
./scripts/bootstrap.sh          # all workspaces
./scripts/bootstrap.sh backend  # single workspace
```

```powershell
# Windows
.\scripts\bootstrap.ps1                  # all workspaces
.\scripts\bootstrap.ps1 -Target backend  # single workspace
```

## Acceptance criteria

- [x] New contributors can bootstrap the active workspace with a documented, repeatable flow
- [x] Setup errors fail with actionable messages
- [x] Windows-first contributors are supported via PowerShell script (with WSL note for Soroban shell scripts)