### PR TITLE
Add PR and issue templates tuned for campaign contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report a bug, issue, or incorrect behavior in the project.
+labels: ["bug", "needs-triage"]
+---
+
+## Summary
+A concise summary of the bug or unexpected behavior.
+
+## Steps to Reproduce
+1. Step one
+2. Step two
+3. Step three
+
+## Expected Behavior
+Describe what should happen.
+
+## Actual Behavior
+Describe what actually happened.
+
+## Testing Evidence
+Include error messages, logs, stack traces, or reproducible test steps.
+
+## Screenshots
+Attach screenshots, screen recordings, or logs if available.
+
+## Related Issues
+Link any related issues or pull requests (e.g. `#123`).
+
+## Additional Context
+Include environment details, browser/device information, or any other relevant context.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature-proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature-proposal.md
@@ -1,0 +1,37 @@
+---
+name: Feature Proposal
+about: Propose a new feature, enhancement, or improvement for the project.
+labels: ["enhancement", "proposal"]
+---
+
+## Summary
+
+A concise summary of the proposed feature or enhancement.
+
+## Problem Statement
+
+Describe the user problem, pain point, or gap this proposal addresses.
+
+## Proposed Solution
+
+Outline the proposed approach and implementation details.
+
+## Acceptance Criteria
+
+List the conditions required for this proposal to be considered complete.
+
+## Testing Evidence
+
+Describe how this proposal can be validated. Include test cases, expected behavior, or verification steps.
+
+## Screenshots / Mockups
+
+Attach screenshots, diagrams, wireframes, or mockups if relevant.
+
+## Related Issues
+
+Link any related issues or discussions (e.g. `#123`).
+
+## Additional Notes
+
+Add any extra context, constraints, or alternatives considered.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+Provide a clear summary of what this PR changes and why.
+
+## Related Issue(s)
+Link any related issue(s) using `#<issue-number>`.
+If this PR closes an issue, include `Closes #<issue-number>`.
+
+## Type of Change
+- [ ] Feature
+- [ ] Fix
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Chore
+
+## Description
+Describe the implementation details and scope of the changes.
+
+## Testing Evidence
+Describe how this change was tested, including commands run or test cases executed.
+Include links to test outputs, screenshots, or any relevant evidence.
+
+## Screenshots
+Add screenshots, GIFs, or recordings when UI or visual behavior changed.
+
+## Checklist
+- [ ] Code builds successfully
+- [ ] Tests added/updated where applicable
+- [ ] Documentation updated if needed
+- [ ] Linked issue referenced
+- [ ] Ready for review


### PR DESCRIPTION
closes: #239 

Added GitHub contribution templates to improve issue and PR submissions:

.github/ISSUE_TEMPLATE/feature-proposal.md
.github/ISSUE_TEMPLATE/bug-report.md
.github/ISSUE_TEMPLATE/config.yml (disables blank issues to enforce structured templates)
.github/pull_request_template.md
These templates include sections for testing evidence, screenshots, linked issues, scope, and expected behavior so contributors have a clearer path for opening issues and PRs.