### PR TITLE
The invoices finally stopped ghosting us—now they’re showing exactly …

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,0 +1,130 @@
+const state = { report: null, activeView: 'merchant' };
+
+function currency(value) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value || 0);
+}
+
+function renderSummary(containerId, report) {
+  const container = document.getElementById(containerId);
+  if (!container || !report) return;
+
+  container.innerHTML = `
+    <article class="summary-tile">
+      <div>Paid invoices</div>
+      <strong>${report.totalPaidInvoices}</strong>
+    </article>
+    <article class="summary-tile">
+      <div>Paid volume</div>
+      <strong>${currency(report.totalPaidVolume)}</strong>
+    </article>
+    <article class="summary-tile">
+      <div>Dominant usage</div>
+      <strong>${report.xlmVsToken.dominant}</strong>
+    </article>
+    <article class="summary-tile">
+      <div>Insight</div>
+      <strong>${report.xlmVsToken.dominantDescription}</strong>
+    </article>
+  `;
+}
+
+function renderBarChart(items, targetId, labelKey = 'asset') {
+  const container = document.getElementById(targetId);
+  if (!container) return;
+
+  if (!items || items.length === 0) {
+    container.innerHTML = '<p>No paid invoices were found for this view.</p>';
+    return;
+  }
+
+  const maxVolume = Math.max(...items.map((item) => item.volume || 0), 1);
+  container.innerHTML = items
+    .map((item) => {
+      const percentage = Math.round(((item.volume || 0) / maxVolume) * 100);
+      const label = item[labelKey] || item.asset || item.network || 'Unknown';
+      return `
+        <div class="chart-row">
+          <span>${label}</span>
+          <div class="bar-track"><div class="bar-fill" style="width:${percentage}%"></div></div>
+          <span>${currency(item.volume || 0)}</span>
+        </div>
+      `;
+    })
+    .join('');
+}
+
+function renderFunnel(funnel, targetId) {
+  const container = document.getElementById(targetId);
+  if (!container) return;
+
+  container.innerHTML = funnel
+    .map((step) => `
+      <div class="chart-row">
+        <span>${step.stage}</span>
+        <div class="bar-track"><div class="bar-fill" style="width:${Math.min(step.conversionRate, 100)}%"></div></div>
+        <span>${step.count}</span>
+      </div>
+    `)
+    .join('');
+}
+
+function renderTimeToPay(metrics, targetId) {
+  const container = document.getElementById(targetId);
+  if (!container) return;
+
+  const summary = metrics || { averageHours: 0, count: 0, method: 'No paid timestamps available' };
+  container.innerHTML = `
+    <div class="summary-tile">
+      <div>Average time-to-pay</div>
+      <strong>${summary.averageHours} hrs</strong>
+    </div>
+    <div class="summary-tile">
+      <div>Computed from</div>
+      <strong>${summary.method}</strong>
+    </div>
+    <div class="summary-tile">
+      <div>Included paid invoices</div>
+      <strong>${summary.count}</strong>
+    </div>
+  `;
+}
+
+function renderMerchantView(report) {
+  renderSummary('merchant-summary', report);
+  renderFunnel(report.conversionMetrics.funnel, 'merchant-funnel');
+  renderBarChart(report.assetBreakdown.slice(0, 5), 'merchant-asset-chart', 'asset');
+}
+
+function renderAdminView(report) {
+  renderSummary('admin-summary', report);
+  renderBarChart(report.assetBreakdown.slice(0, 5), 'admin-asset-chart', 'asset');
+  renderBarChart(report.networkBreakdown.slice(0, 5), 'admin-network-chart', 'network');
+  renderFunnel(report.conversionMetrics.funnel, 'admin-funnel');
+  renderTimeToPay(report.conversionMetrics.timeToPay, 'admin-time-to-pay');
+}
+
+async function loadReport() {
+  const response = await fetch('/api/asset-report');
+  const report = await response.json();
+  state.report = report;
+  renderMerchantView(report);
+  renderAdminView(report);
+}
+
+function activateView(view) {
+  state.activeView = view;
+  document.getElementById('merchant-view').classList.toggle('hidden', view !== 'merchant');
+  document.getElementById('admin-view').classList.toggle('hidden', view !== 'admin');
+  document.querySelectorAll('.toggle-button').forEach((button) => {
+    button.classList.toggle('active', button.dataset.view === view);
+  });
+}
+
+document.querySelectorAll('.toggle-button').forEach((button) => {
+  button.addEventListener('click', () => activateView(button.dataset.view));
+});
+
+loadReport().catch((error) => {
+  console.error('Failed to load reporting data', error);
+  document.body.innerHTML = '<main class="shell"><p>Could not load the reporting summary.</p></main>';
+});

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Invoice Asset Usage Insights</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Operational reporting</p>
+          <h1>Asset and network path usage</h1>
+          <p class="subtitle">Merchants and admins can quickly see whether XLM or token payments are leading, with supporting network metadata surfaced next to each trend.</p>
+        </div>
+        <div class="toggle" role="tablist" aria-label="reporting views">
+          <button class="toggle-button active" data-view="merchant">Merchant view</button>
+          <button class="toggle-button" data-view="admin">Admin view</button>
+        </div>
+      </header>
+
+      <section id="merchant-view" class="view-card">
+        <h2>Merchant summary</h2>
+        <div id="merchant-summary" class="summary-grid"></div>
+        <div class="dual-grid">
+          <div>
+            <h3>Conversion funnel</h3>
+            <div id="merchant-funnel" class="chart-list"></div>
+          </div>
+          <div>
+            <h3>Asset mix</h3>
+            <div id="merchant-asset-chart" class="chart-list"></div>
+          </div>
+        </div>
+      </section>
+
+      <section id="admin-view" class="view-card hidden">
+        <h2>Admin insights</h2>
+        <div id="admin-summary" class="summary-grid"></div>
+        <div class="dual-grid">
+          <div>
+            <h3>Top assets</h3>
+            <div id="admin-asset-chart" class="chart-list"></div>
+          </div>
+          <div>
+            <h3>Top network paths</h3>
+            <div id="admin-network-chart" class="chart-list"></div>
+          </div>
+        </div>
+        <div class="dual-grid">
+          <div>
+            <h3>Conversion funnel</h3>
+            <div id="admin-funnel" class="chart-list"></div>
+          </div>
+          <div>
+            <h3>Time-to-pay</h3>
+            <div id="admin-time-to-pay" class="chart-list"></div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,0 +1,56 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  --bg: #f4f6fb;
+  --card: #ffffff;
+  --text: #111827;
+  --muted: #64748b;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --border: #dbe4f0;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+.shell { max-width: 1120px; margin: 0 auto; padding: 2rem; }
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+.eyebrow { text-transform: uppercase; letter-spacing: 0.2em; color: var(--accent); font-weight: 700; margin: 0 0 0.25rem; }
+.subtitle { color: var(--muted); max-width: 640px; }
+.toggle { display: flex; gap: 0.5rem; }
+.toggle-button {
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.toggle-button.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.view-card { background: var(--card); border: 1px solid var(--border); border-radius: 18px; padding: 1.25rem; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06); }
+.hidden { display: none; }
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-bottom: 1rem;
+}
+.summary-tile { border: 1px solid var(--border); border-radius: 12px; padding: 0.95rem; background: linear-gradient(135deg, var(--accent-soft), #fff); }
+.summary-tile strong { display: block; font-size: 1.1rem; margin-top: 0.4rem; }
+.chart-list { display: grid; gap: 0.8rem; }
+.chart-row { display: grid; grid-template-columns: 110px 1fr 70px; align-items: center; gap: 0.75rem; }
+.bar-track { height: 10px; border-radius: 999px; overflow: hidden; background: var(--bg); }
+.bar-fill { height: 100%; border-radius: inherit; background: linear-gradient(90deg, var(--accent), #60a5fa); }
+.metric-pill { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.4rem 0.7rem; border-radius: 999px; background: var(--accent-soft); color: var(--accent); font-size: 0.9rem; }
+.dual-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+@media (max-width: 780px) { .hero { flex-direction: column; align-items: flex-start; } }

--- a/server/asset-reporting.js
+++ b/server/asset-reporting.js
@@ -1,0 +1,168 @@
+function toDisplayLabel(value, fallback = 'Unknown') {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === 'string' && value.trim() === '') return fallback;
+  return String(value);
+}
+
+function normalizeNetwork(value) {
+  return toDisplayLabel(value, 'Unknown').toLowerCase();
+}
+
+function classifyAsset(asset) {
+  const rawAsset = toDisplayLabel(asset, 'Unknown');
+  const normalized = rawAsset.toLowerCase();
+  if (normalized === 'xlm' || normalized === 'native' || normalized === 'stellar') {
+    return 'XLM';
+  }
+  return 'Token';
+}
+
+function parseTimestamp(value) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function buildAssetReport(invoices = []) {
+  const safeInvoices = Array.isArray(invoices) ? invoices : [];
+  const paidInvoices = safeInvoices.filter((invoice) => {
+    const status = toDisplayLabel(invoice?.status || invoice?.state, '').toLowerCase();
+    return status === 'paid' || Boolean(invoice?.paid_at || invoice?.settled_at);
+  });
+
+  const assetBuckets = new Map();
+  const networkBuckets = new Map();
+  const xlmVsToken = {
+    xlm: { count: 0, volume: 0 },
+    token: { count: 0, volume: 0 }
+  };
+
+  const createdCount = safeInvoices.length;
+  const sharedCount = safeInvoices.filter((invoice) => Boolean(invoice?.shared_at || invoice?.shared || invoice?.sent_at)).length;
+  const viewedCount = safeInvoices.filter((invoice) => Boolean(invoice?.viewed_at || invoice?.viewed || invoice?.opened_at)).length;
+  const paidCount = paidInvoices.length;
+
+  const timeToPaySamples = [];
+
+  paidInvoices.forEach((invoice) => {
+    const amount = Number(invoice?.amount ?? invoice?.total ?? invoice?.paid_amount ?? 0);
+    const assetName = toDisplayLabel(invoice?.asset_type || invoice?.asset || invoice?.asset_code || invoice?.currency || invoice?.symbol, 'Unknown');
+    const networkName = toDisplayLabel(invoice?.network || invoice?.supporting_network || invoice?.network_path || invoice?.payment_network || invoice?.path || invoice?.channel, 'Unknown');
+    const assetKind = classifyAsset(assetName);
+    const networkKey = normalizeNetwork(networkName);
+    const createdAt = parseTimestamp(invoice?.created_at || invoice?.createdAt || invoice?.created);
+    const paidAt = parseTimestamp(invoice?.paid_at || invoice?.paidAt || invoice?.settled_at || invoice?.settledAt);
+
+    if (createdAt && paidAt) {
+      const diffHours = (paidAt.getTime() - createdAt.getTime()) / 36e5;
+      if (Number.isFinite(diffHours) && diffHours >= 0) {
+        timeToPaySamples.push(diffHours);
+      }
+    }
+
+    if (assetKind === 'XLM') {
+      xlmVsToken.xlm.count += 1;
+      xlmVsToken.xlm.volume += Number.isFinite(amount) ? amount : 0;
+    } else {
+      xlmVsToken.token.count += 1;
+      xlmVsToken.token.volume += Number.isFinite(amount) ? amount : 0;
+    }
+
+    const assetBucket = assetBuckets.get(assetName) || {
+      asset: assetName,
+      count: 0,
+      volume: 0,
+      networks: new Map()
+    };
+    assetBucket.count += 1;
+    assetBucket.volume += Number.isFinite(amount) ? amount : 0;
+
+    const networkBucket = assetBucket.networks.get(networkKey) || { network: networkName, count: 0, volume: 0 };
+    networkBucket.count += 1;
+    networkBucket.volume += Number.isFinite(amount) ? amount : 0;
+    assetBucket.networks.set(networkKey, networkBucket);
+    assetBuckets.set(assetName, assetBucket);
+
+    const networkAggregate = networkBuckets.get(networkKey) || {
+      network: networkName,
+      count: 0,
+      volume: 0,
+      assets: new Map()
+    };
+    networkAggregate.count += 1;
+    networkAggregate.volume += Number.isFinite(amount) ? amount : 0;
+
+    const assetContribution = networkAggregate.assets.get(assetName) || { asset: assetName, count: 0, volume: 0 };
+    assetContribution.count += 1;
+    assetContribution.volume += Number.isFinite(amount) ? amount : 0;
+    networkAggregate.assets.set(assetName, assetContribution);
+    networkBuckets.set(networkKey, networkAggregate);
+  });
+
+  const assetBreakdown = Array.from(assetBuckets.values())
+    .map((entry) => ({
+      asset: entry.asset,
+      count: entry.count,
+      volume: entry.volume,
+      networks: Array.from(entry.networks.values()).sort((left, right) => right.volume - left.volume)
+    }))
+    .sort((left, right) => right.volume - left.volume);
+
+  const networkBreakdown = Array.from(networkBuckets.values())
+    .map((entry) => ({
+      network: entry.network,
+      count: entry.count,
+      volume: entry.volume,
+      assets: Array.from(entry.assets.values()).sort((left, right) => right.volume - left.volume)
+    }))
+    .sort((left, right) => right.volume - left.volume);
+
+  const xlmVolume = xlmVsToken.xlm.volume;
+  const tokenVolume = xlmVsToken.token.volume;
+  const dominant = xlmVolume >= tokenVolume ? 'XLM' : 'Tokens';
+  const dominantDescription = xlmVolume === tokenVolume
+    ? 'Usage is evenly split between XLM and token-based payments.'
+    : dominant === 'XLM'
+      ? 'XLM payments dominate usage.'
+      : 'Token-based payments dominate usage.';
+
+  const averageHours = timeToPaySamples.length > 0
+    ? Number((timeToPaySamples.reduce((sum, value) => sum + value, 0) / timeToPaySamples.length).toFixed(2))
+    : 0;
+
+  return {
+    totalPaidInvoices: paidInvoices.length,
+    totalPaidVolume: paidInvoices.reduce((sum, invoice) => sum + Number(invoice?.amount ?? invoice?.total ?? invoice?.paid_amount ?? 0), 0),
+    assetBreakdown,
+    networkBreakdown,
+    xlmVsToken: {
+      ...xlmVsToken,
+      dominant,
+      dominantDescription
+    },
+    conversionMetrics: {
+      createdCount,
+      sharedCount,
+      viewedCount,
+      paidCount,
+      funnel: [
+        { stage: 'Created', count: createdCount, conversionRate: 100 },
+        { stage: 'Shared', count: sharedCount, conversionRate: createdCount > 0 ? Number(((sharedCount / createdCount) * 100).toFixed(1)) : 0 },
+        { stage: 'Viewed', count: viewedCount, conversionRate: createdCount > 0 ? Number(((viewedCount / createdCount) * 100).toFixed(1)) : 0 },
+        { stage: 'Paid', count: paidCount, conversionRate: createdCount > 0 ? Number(((paidCount / createdCount) * 100).toFixed(1)) : 0 }
+      ],
+      timeToPay: {
+        unit: 'hours',
+        count: timeToPaySamples.length,
+        averageHours,
+        method: 'Difference between created_at and paid_at timestamps'
+      }
+    }
+  };
+}
+
+module.exports = {
+  buildAssetReport,
+  classifyAsset,
+  toDisplayLabel
+};

--- a/server/asset-reporting.test.js
+++ b/server/asset-reporting.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { buildAssetReport } = require('./asset-reporting');
+
+const report = buildAssetReport([
+  { id: 'inv-1', status: 'paid', amount: 120, asset_type: 'XLM', network: 'stellar', created_at: '2024-01-01T10:00:00Z', shared_at: '2024-01-01T10:15:00Z', viewed_at: '2024-01-01T10:30:00Z', paid_at: '2024-01-01T11:00:00Z' },
+  { id: 'inv-2', status: 'paid', amount: 80, asset_type: 'USDC', network: 'stellar', created_at: '2024-01-02T10:00:00Z', shared_at: '2024-01-02T10:10:00Z', paid_at: '2024-01-02T10:45:00Z' },
+  { id: 'inv-3', status: 'pending', amount: 40, asset_type: 'USDT', network: 'ethereum', created_at: '2024-01-03T10:00:00Z', shared_at: '2024-01-03T10:20:00Z' },
+  { id: 'inv-4', status: 'paid', amount: 18, asset_type: '', network: '', created_at: '2024-01-04T09:00:00Z', paid_at: '2024-01-04T09:30:00Z' }
+]);
+
+assert.strictEqual(report.totalPaidInvoices, 3);
+assert.strictEqual(report.xlmVsToken.dominant, 'XLM');
+assert.strictEqual(report.assetBreakdown[0].asset, 'XLM');
+assert.strictEqual(report.networkBreakdown[0].network, 'stellar');
+assert.ok(report.assetBreakdown.some((item) => item.asset === 'Unknown'));
+assert.ok(report.networkBreakdown.some((item) => item.network === 'Unknown'));
+assert.strictEqual(report.conversionMetrics.createdCount, 4);
+assert.strictEqual(report.conversionMetrics.sharedCount, 3);
+assert.strictEqual(report.conversionMetrics.viewedCount, 1);
+assert.strictEqual(report.conversionMetrics.paidCount, 3);
+assert.strictEqual(report.conversionMetrics.funnel[1].stage, 'Shared');
+assert.strictEqual(report.conversionMetrics.funnel[3].stage, 'Paid');
+assert.strictEqual(report.conversionMetrics.timeToPay.unit, 'hours');
+assert.strictEqual(report.conversionMetrics.timeToPay.count, 3);
+assert.strictEqual(report.conversionMetrics.timeToPay.averageHours, 0.75);
+assert.strictEqual(report.conversionMetrics.timeToPay.method, 'Difference between created_at and paid_at timestamps');
+console.log('asset-reporting tests passed');


### PR DESCRIPTION
This change adds invoice lifecycle reporting for created, shared, viewed, and paid events, along with consistent time-to-pay calculations based on created_at and paid_at timestamps.
Merchants and admins can now compare invoice volume against actual payment conversion and view a clear funnel and timing summary in the reporting experience.
The implementation also preserves asset and network breakdowns while handling sparse or mixed metadata gracefully.

closes #243