### PR TITLE
Sync .env.example coverage and setup docs across all active apps

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report a bug, issue, or incorrect behavior in the project.
+labels: ["bug", "needs-triage"]
+---
+
+## Summary
+A concise summary of the bug or unexpected behavior.
+
+## Steps to Reproduce
+1. Step one
+2. Step two
+3. Step three
+
+## Expected Behavior
+Describe what should happen.
+
+## Actual Behavior
+Describe what actually happened.
+
+## Testing Evidence
+Include error messages, logs, stack traces, or reproducible test steps.
+
+## Screenshots
+Attach screenshots, screen recordings, or logs if available.
+
+## Related Issues
+Link any related issues or pull requests (e.g. `#123`).
+
+## Additional Context
+Include environment details, browser/device information, or any other relevant context.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature-proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature-proposal.md
@@ -1,0 +1,37 @@
+---
+name: Feature Proposal
+about: Propose a new feature, enhancement, or improvement for the project.
+labels: ["enhancement", "proposal"]
+---
+
+## Summary
+
+A concise summary of the proposed feature or enhancement.
+
+## Problem Statement
+
+Describe the user problem, pain point, or gap this proposal addresses.
+
+## Proposed Solution
+
+Outline the proposed approach and implementation details.
+
+## Acceptance Criteria
+
+List the conditions required for this proposal to be considered complete.
+
+## Testing Evidence
+
+Describe how this proposal can be validated. Include test cases, expected behavior, or verification steps.
+
+## Screenshots / Mockups
+
+Attach screenshots, diagrams, wireframes, or mockups if relevant.
+
+## Related Issues
+
+Link any related issues or discussions (e.g. `#123`).
+
+## Additional Notes
+
+Add any extra context, constraints, or alternatives considered.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+Provide a clear summary of what this PR changes and why.
+
+## Related Issue(s)
+Link any related issue(s) using `#<issue-number>`.
+If this PR closes an issue, include `Closes #<issue-number>`.
+
+## Type of Change
+- [ ] Feature
+- [ ] Fix
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Chore
+
+## Description
+Describe the implementation details and scope of the changes.
+
+## Testing Evidence
+Describe how this change was tested, including commands run or test cases executed.
+Include links to test outputs, screenshots, or any relevant evidence.
+
+## Screenshots
+Add screenshots, GIFs, or recordings when UI or visual behavior changed.
+
+## Checklist
+- [ ] Code builds successfully
+- [ ] Tests added/updated where applicable
+- [ ] Documentation updated if needed
+- [ ] Linked issue referenced
+- [ ] Ready for review

--- a/.kiro/specs/env-setup-alignment/.config.kiro
+++ b/.kiro/specs/env-setup-alignment/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "60ce1e0a-d572-4760-943a-2f70f636d431", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/env-setup-alignment/design.md
+++ b/.kiro/specs/env-setup-alignment/design.md
@@ -1,0 +1,330 @@
+# Design Document: env-setup-alignment
+
+## Overview
+
+This feature eliminates the environment-variable setup friction that contributors encounter when cloning Invoisio. Four active app surfaces currently have inconsistent or missing `.env.example` files, which forces contributors to inspect source code to discover what variables are required.
+
+The work is entirely file-level: no new runtime code is introduced. The deliverables are:
+
+1. A patched `backend/.env.example` — complete, annotated, and grouped.
+2. A new `web/.env.example` — all `NEXT_PUBLIC_*` variables.
+3. A new `mobile/.env.example` — all `@env` variables from `env.d.ts`.
+4. A new `soroban/client/.env.example` — all contract client variables.
+5. Root `.gitignore` update — `!**/.env.example` negation so all four files are git-tracked.
+6. Root `README.md` update — "Environment Setup" section.
+7. `web/README.md`, `mobile/SMOKE_TEST_CHECKLIST.md`, and `soroban/README.md` updates — copy commands.
+
+### Non-goals
+
+- No changes to application source code.
+- No changes to Joi schema or config factories.
+- No changes to CI pipelines or deployment configuration.
+- No secret rotation or real credential exposure.
+
+---
+
+## Architecture
+
+This feature is purely documentation/configuration: it produces static files tracked in git. There is no runtime component, service, or API surface.
+
+```
+repo root
+├── .gitignore                   ← patch: add !**/.env.example negation
+├── README.md                    ← patch: add Environment Setup section
+├── backend/
+│   └── .env.example             ← patch: complete all Joi vars, group sections, annotate
+├── web/
+│   ├── .env.example             ← new file
+│   └── README.md                ← patch: add cp setup step
+├── mobile/
+│   ├── .env.example             ← new file
+│   └── SMOKE_TEST_CHECKLIST.md  ← patch: add cp setup step before smoke tests
+└── soroban/
+    ├── README.md                ← patch: add cp step in TypeScript Client Helper section
+    └── client/
+        └── .env.example         ← new file
+```
+
+The root `.gitignore` currently contains `.env.*`, which glob-matches `.env.example`. The `!**/.env.example` negation rule placed after that pattern explicitly unignores all `.env.example` files throughout the monorepo. Git processes `.gitignore` rules in order, so the negation overrides the earlier match.
+
+---
+
+## Components and Interfaces
+
+### 1. `backend/.env.example` (patch)
+
+**Source of truth**: The Joi `validationSchema` in `backend/src/app.module.ts`.
+
+All 27 validated variables must be present. Variables are grouped by domain using `# ── Section Name ──` headers. Each variable carries either `# required` or `# optional`, matching its Joi designation. Secret variables (`JWT_SECRET`, `ADMIN_SECRET_KEY`, `REDIS_PASSWORD`) carry a `WARNING: never commit a real value` comment. Required-with-no-default variables (`DATABASE_URL`, `JWT_SECRET`) include generation guidance comments.
+
+Section order and variables:
+
+| Section | Variables |
+|---------|-----------|
+| `Database` | `DATABASE_URL` |
+| `JWT` | `JWT_SECRET` |
+| `App` | `PORT`, `CORS_ORIGIN` |
+| `Stellar Network` | `HORIZON_URL`, `STELLAR_NETWORK_PASSPHRASE`, `MERCHANT_PUBLIC_KEY`, `USDC_ISSUER`, `USDC_ASSET_CODE`, `MEMO_PREFIX`, `HORIZON_POLL_INTERVAL` |
+| `Soroban Contract` | `SOROBAN_RPC_URL`, `SOROBAN_CONTRACT_ID`, `ADMIN_SECRET_KEY`, `SOROBAN_EVENT_TOPIC` |
+| `Rate Limiting` | `THROTTLE_TTL`, `THROTTLE_LIMIT`, `THROTTLE_AUTH_TTL`, `THROTTLE_AUTH_LIMIT`, `THROTTLE_INVOICE_TTL`, `THROTTLE_INVOICE_LIMIT` |
+| `Redis` | `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`, `REDIS_KEY_PREFIX` |
+| `Observability` | `SLOW_DB_THRESHOLD_MS`, `SLOW_NETWORK_THRESHOLD_MS` |
+
+### 2. `web/.env.example` (new)
+
+**Source of truth**: All `process.env.NEXT_PUBLIC_*` reads in `web/` source.
+
+Current reads (from static analysis):
+- `NEXT_PUBLIC_API_URL` — read in `web/lib/api-client.ts` (has fallback `http://localhost:3001`, so it is optional at runtime but must be documented).
+- `NEXT_PUBLIC_USDC_ISSUER` — read in `web/app/pos/page.tsx` (has fallback, documented as optional with testnet default).
+
+Format: two sections (`API` and `Stellar`), each variable annotated.
+
+### 3. `mobile/.env.example` (new)
+
+**Source of truth**: All `export const` declarations in `mobile/types/env.d.ts`.
+
+Variables: `API_URL`, `STELLAR_NETWORK_PASSPHRASE`, `REOWN_PROJECT_ID`, `APP_NAME`.
+
+`REOWN_PROJECT_ID` has no safe default and requires a contributor-specific value; it gets a `# required — obtain from https://cloud.reown.com` comment.
+
+Note: `mobile/.gitignore` uses `.env*.local` (not `.env.*`), so it does not match `.env.example`. The root `.gitignore` uses `.env.*`, which does match. The `!**/.env.example` negation in the root `.gitignore` resolves this.
+
+### 4. `soroban/client/.env.example` (new)
+
+**Source of truth**: `process.env.*` reads in `soroban/client/examples/` and `soroban/client/src/`.
+
+Variables from static analysis:
+- `SOROBAN_RPC_URL` — `requireEnv()` in `record-payment.ts`, `query-payment.ts`; with fallback in `query-config.ts`.
+- `STELLAR_NETWORK_PASSPHRASE` — `requireEnv()` in `record-payment.ts`, `query-payment.ts`; with fallback in `query-config.ts`.
+- `SOROBAN_CONTRACT_ID` — `requireEnv()` in `record-payment.ts`, `query-payment.ts`.
+- `CONTRACT_ID` — direct `process.env.CONTRACT_ID` in `query-config.ts` (different from `SOROBAN_CONTRACT_ID`).
+- `ADMIN_SECRET_KEY` — `requireEnv()` in `record-payment.ts`.
+- `SOURCE_PUBLIC_KEY` — optional fallback read in `query-config.ts`, `query-payment.ts`.
+- `PAYER_PUBLIC_KEY` — `requireEnv()` in `record-payment.ts`; fallback in `query-payment.ts`.
+- `INVOICE_ID` — optional override in `record-payment.ts`, `query-payment.ts`.
+
+`ADMIN_SECRET_KEY` (value starts with `S`, Stellar secret key) carries the `WARNING: never commit a real value` comment.
+
+### 5. Root `.gitignore` (patch)
+
+Add `!**/.env.example` as a negation rule after the `.env.*` line. Git evaluates rules sequentially; a later negation overrides an earlier match. This single rule unignores all `.env.example` files in all subdirectories.
+
+### 6. Documentation updates
+
+| File | Change |
+|------|--------|
+| `README.md` | Add "Environment Setup" section naming all four surfaces with their `.env.example` paths and per-app setup links |
+| `web/README.md` | Add environment setup step with `cp web/.env.example web/.env.local` before `npm run dev` |
+| `mobile/SMOKE_TEST_CHECKLIST.md` | Add environment setup step with `cp mobile/.env.example mobile/.env` in the "Before you start" section |
+| `soroban/README.md` | Add `cp soroban/client/.env.example soroban/client/.env` step in the "TypeScript Client Helper → Setup" subsection |
+
+---
+
+## Data Models
+
+There is no runtime data model. The canonical "model" is the Joi validation schema in `backend/src/app.module.ts`, which defines the authoritative variable names, types, defaults, and required/optional designations for the backend. The other surfaces derive their variable lists from their respective source of truth (typed module declarations for mobile, static `process.env` reads for web and Soroban client).
+
+### Variable inventory (all surfaces)
+
+```
+backend/.env.example   (27 vars from Joi schema)
+  DATABASE_URL          required, no default
+  JWT_SECRET            required, no default, secret
+  PORT                  optional, default 3001
+  CORS_ORIGIN           optional, default http://localhost:3000
+  HORIZON_URL           optional, default https://horizon-testnet.stellar.org
+  STELLAR_NETWORK_PASSPHRASE  optional, default "Test SDF Network ; September 2015"
+  MERCHANT_PUBLIC_KEY   optional, allow ""
+  USDC_ISSUER           optional, default GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+  USDC_ASSET_CODE       optional, default USDC
+  MEMO_PREFIX           optional, default invoisio-
+  HORIZON_POLL_INTERVAL optional, default 15000
+  SOROBAN_RPC_URL       optional, default https://soroban-testnet.stellar.org
+  SOROBAN_CONTRACT_ID   optional, allow ""
+  ADMIN_SECRET_KEY      optional, allow "", secret
+  SOROBAN_EVENT_TOPIC   optional, default InvoicePaymentRecorded
+  THROTTLE_TTL          optional, default 60
+  THROTTLE_LIMIT        optional, default 100
+  THROTTLE_AUTH_TTL     optional, default 900
+  THROTTLE_AUTH_LIMIT   optional, default 5
+  THROTTLE_INVOICE_TTL  optional, default 3600
+  THROTTLE_INVOICE_LIMIT optional, default 20
+  REDIS_HOST            optional, default localhost
+  REDIS_PORT            optional, default 6379
+  REDIS_PASSWORD        optional, allow "", secret
+  REDIS_DB              optional, default 0
+  REDIS_KEY_PREFIX      optional, default invoisio:throttle:
+  SLOW_DB_THRESHOLD_MS  optional, default 200
+  SLOW_NETWORK_THRESHOLD_MS optional, default 500
+
+web/.env.example       (2 vars from process.env reads)
+  NEXT_PUBLIC_API_URL           optional, default http://localhost:3001
+  NEXT_PUBLIC_USDC_ISSUER       optional, testnet default GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+
+mobile/.env.example    (4 vars from env.d.ts)
+  API_URL                       optional, default http://localhost:3001
+  STELLAR_NETWORK_PASSPHRASE    optional, default "Test SDF Network ; September 2015"
+  REOWN_PROJECT_ID              required, no safe default
+  APP_NAME                      optional, default Invoisio
+
+soroban/client/.env.example  (8 vars from examples + src)
+  SOROBAN_RPC_URL               required
+  STELLAR_NETWORK_PASSPHRASE    required
+  SOROBAN_CONTRACT_ID           required
+  CONTRACT_ID                   required (read by query-config.ts via process.env.CONTRACT_ID)
+  ADMIN_SECRET_KEY              optional for reads, required for writes, secret
+  SOURCE_PUBLIC_KEY             optional
+  PAYER_PUBLIC_KEY              optional
+  INVOICE_ID                    optional, default invoisio-demo-001
+```
+
+### Shared variable consistency
+
+The following variables appear across multiple surfaces and must carry byte-for-byte identical values:
+
+| Variable | Shared across | Required value |
+|----------|--------------|----------------|
+| `STELLAR_NETWORK_PASSPHRASE` | backend, mobile, soroban/client | `"Test SDF Network ; September 2015"` |
+| `SOROBAN_RPC_URL` | backend, soroban/client | `https://soroban-testnet.stellar.org` |
+| `USDC_ISSUER` / `NEXT_PUBLIC_USDC_ISSUER` | backend, web | `GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN` |
+| `API_URL` / `NEXT_PUBLIC_API_URL` | mobile, web | `http://localhost:3001` |
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+This feature is file-generation and documentation: it does not implement algorithms, parsers, or data transformations. Most acceptance criteria are concrete example-based checks (does file X contain line Y?). However, several criteria express universal invariants that hold across a dynamic set of inputs — specifically the set of variable lines in the files, the set of variables declared in source, and the set of files across the four surfaces. These are good candidates for property-based testing.
+
+**Property Reflection:**
+
+After reviewing all prework classifications, five properties were identified. On reflection:
+- Properties 1 and 4 both test "every variable line has a required/optional annotation"; Property 1 tests backend only, Property 4 generalises to all four files. Property 1 is subsumed by Property 4 — consolidated.
+- Property 3 (completeness for web) and Property 5 (completeness for all surfaces) overlap. Property 5 subsumes Property 3 — consolidated.
+- Properties 2 (mobile env.d.ts sync) and the source-read-completeness are distinct enough to keep separate since they target different source-of-truth files.
+
+After reflection, four non-redundant properties remain:
+
+---
+
+### Property 1: All variable lines in every .env.example carry a required/optional annotation
+
+*For any* variable line (a line matching the pattern `KEY=VALUE`) in any of the four `.env.example` files (`backend/.env.example`, `web/.env.example`, `mobile/.env.example`, `soroban/client/.env.example`), that line or the line immediately above it SHALL contain either the substring `# required` or the substring `# optional`.
+
+**Validates: Requirements 1.6, 5.1**
+
+---
+
+### Property 2: Every variable declared in mobile/types/env.d.ts appears in mobile/.env.example
+
+*For any* `export const VAR` declaration in `mobile/types/env.d.ts`, the variable name `VAR` SHALL appear as a key in `mobile/.env.example`. If a new variable is added to `env.d.ts`, the property fails until `mobile/.env.example` is updated to include it.
+
+**Validates: Requirements 3.2**
+
+---
+
+### Property 3: Shared Stellar variables are byte-for-byte identical across all files that include them
+
+*For any* variable name that appears in two or more of the four `.env.example` files (including semantic equivalents such as `USDC_ISSUER` in the backend and `NEXT_PUBLIC_USDC_ISSUER` in the web, both referencing the same USDC issuer address), the assigned values SHALL be byte-for-byte identical.
+
+**Validates: Requirements 5.2**
+
+---
+
+### Property 4: Every process.env.* or @env read without a hardcoded fallback is documented in its surface's .env.example
+
+*For any* `process.env.VAR` read (or `@env` import of `VAR`) in any of the four app surfaces' source files where no hardcoded fallback is provided at the call site, the variable name `VAR` SHALL appear as a key in that surface's `.env.example`.
+
+**Validates: Requirements 2.4, 5.5**
+
+---
+
+## Error Handling
+
+Because this feature produces only static files (no runtime code), traditional error handling does not apply. The relevant failure modes are:
+
+| Failure mode | Mitigation |
+|---|---|
+| A `.env.example` is git-ignored despite the negation rule | The root `.gitignore` negation `!**/.env.example` must appear after the `.env.*` line. Verified by running `git check-ignore -v path/to/.env.example` during review. |
+| A Joi variable is added to `app.module.ts` but not to `backend/.env.example` | Property 4 and the example-based completeness test (1.1) catch this. |
+| A variable is added to `mobile/types/env.d.ts` but not to `mobile/.env.example` | Property 2 catches this. |
+| Shared Stellar values drift between surfaces | Property 3 catches this. |
+| A real secret value is accidentally placed in an `.env.example` | Secret variables use placeholder values only (`SXXX...`, `change-me-generate-with-openssl`, etc.). The `WARNING: never commit a real value` comment is both a user signal and an auditable marker. |
+| Copy command in documentation refers to wrong file path | Each copy command references exact repo-relative paths validated during implementation. |
+
+---
+
+## Testing Strategy
+
+This feature uses a dual approach:
+
+### Unit / example-based tests
+
+Example tests are appropriate here because most acceptance criteria are concrete, deterministic checks against a fixed set of files and a known variable inventory. They run fast and require no randomisation.
+
+**Test file location**: `backend/src/` or a dedicated `tests/env-examples/` directory (plain Node.js or Jest).
+
+Key example tests:
+
+1. **Backend completeness** — Parse `backend/.env.example` and assert all 27 Joi-schema variable names are present as keys.
+2. **Backend defaults** — For each variable with a Joi default, assert the `.env.example` value matches the default.
+3. **Backend secrets** — Assert `JWT_SECRET`, `ADMIN_SECRET_KEY`, and `REDIS_PASSWORD` each have a `WARNING: never commit a real value` comment.
+4. **Backend section headers** — Assert all 7 `# ── Section Name ──` headers are present in the correct order.
+5. **Web file existence and variables** — Assert `web/.env.example` exists, contains `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_USDC_ISSUER` with expected values and annotations.
+6. **Mobile file existence and variables** — Assert `mobile/.env.example` exists and contains the 4 declared variables with expected values.
+7. **Soroban client file** — Assert `soroban/client/.env.example` exists and contains all 8 variables with specified values and comments.
+8. **Documentation copy commands** — Assert each README/checklist contains the exact copy command string.
+9. **Root README Environment Setup** — Assert root `README.md` contains "Environment Setup" section referencing all four surfaces.
+
+### Property-based tests
+
+Property-based testing is applicable because four of the acceptance criteria express universal invariants over the variable-line set, the `env.d.ts` declaration set, and the set of `process.env` reads. These sets can change as contributors add new variables, so property tests catch future regressions automatically.
+
+**Library**: [fast-check](https://github.com/dubzzz/fast-check) (TypeScript, works with Jest/Vitest).
+
+**Minimum iterations**: 100 per property test.
+
+**Tag format**: `// Feature: env-setup-alignment, Property {N}: {property_text}`
+
+#### Property test 1 — Annotation completeness
+
+```
+// Feature: env-setup-alignment, Property 1: All variable lines carry required/optional annotation
+```
+
+For each of the four `.env.example` files, parse all lines. Use `fc.constantFrom(...lines)` to generate a random variable line from the file. Assert that the line or the preceding line contains `# required` or `# optional`.
+
+#### Property test 2 — env.d.ts / mobile sync
+
+```
+// Feature: env-setup-alignment, Property 2: Every env.d.ts variable appears in mobile/.env.example
+```
+
+Parse `mobile/types/env.d.ts` to extract all exported variable names. Use `fc.constantFrom(...varNames)` to generate a random declared variable. Assert it appears as a key in `mobile/.env.example`.
+
+#### Property test 3 — Shared variable consistency
+
+```
+// Feature: env-setup-alignment, Property 3: Shared Stellar variables are identical across files
+```
+
+For each of the four shared-variable pairs (see Data Models section), parse the value from each relevant file. Assert the values are byte-for-byte identical.
+
+#### Property test 4 — Source-read completeness
+
+```
+// Feature: env-setup-alignment, Property 4: Every undocumented process.env read appears in .env.example
+```
+
+For each surface, maintain a static list of `process.env.VAR` reads without hardcoded fallbacks (derived from static analysis). Use `fc.constantFrom(...reads)` to generate a random undocumented read. Assert the variable name appears in the corresponding `.env.example`.
+
+### Notes on PBT applicability
+
+These property tests are appropriate because:
+- The input space is the set of variable-line strings and declared variable names — finite but open-ended as the codebase grows.
+- Input variation reveals real regressions: adding a variable to source without updating the example file fails Property 4.
+- All operations are in-memory file parsing — no external services, fast, cost-effective at 100+ iterations.
+
+Integration tests (e.g., running `git check-ignore`) are used only as smoke tests to verify git tracking, not as property-based tests, because they test external tool behavior and don't benefit from multiple iterations.

--- a/.kiro/specs/env-setup-alignment/requirements.md
+++ b/.kiro/specs/env-setup-alignment/requirements.md
@@ -1,0 +1,97 @@
+# Requirements Document
+
+## Introduction
+
+Contributors to Invoisio currently face friction when setting up their local environment because environment variable documentation is inconsistent across the four active app surfaces: the NestJS backend, the Next.js web app, the Expo mobile app, and the Soroban smart-contract client. The backend has a reasonably complete `.env.example`, but the web and mobile apps have no example files at all, and the Soroban client lacks a `.env.example` despite its README referencing one. This feature audits the required env vars for every active app and ensures each surface ships with a clear, complete, and consistently formatted example file so any contributor can get running with a single copy-and-edit step.
+
+## Glossary
+
+- **Backend**: The NestJS API located at `backend/`, the primary runtime that coordinates Stellar payments, invoice management, and authentication.
+- **Web**: The Next.js frontend located at `web/`, consumed by browser-based merchants.
+- **Mobile**: The Expo / React Native app located at `mobile/`, consumed by merchants on iOS and Android.
+- **Soroban_Client**: The TypeScript helper library located at `soroban/client/`, used by example scripts and the Backend to interact with the deployed Soroban smart contract.
+- **Env_Example_File**: A committed `.env.example` file that documents every environment variable an app reads, with safe placeholder values and inline comments.
+- **Critical_Var**: An environment variable whose absence causes the app to fail to start, throw an unhandled error at runtime, or silently produce wrong behavior (e.g., connecting to the wrong Stellar network).
+- **Optional_Var**: An environment variable that has a safe default and whose absence does not prevent the app from starting or operating in development mode.
+- **Contributor**: A developer who clones the repository and wants to run one or more app surfaces locally.
+- **README**: The per-app `README.md` that a Contributor reads first when setting up a surface.
+
+---
+
+## Requirements
+
+### Requirement 1: Backend env example completeness
+
+**User Story:** As a Contributor, I want the backend `.env.example` to document every variable the server reads, so that I can configure the backend without inspecting source code.
+
+#### Acceptance Criteria
+
+1. THE Backend `backend/.env.example` SHALL include every variable validated by the Joi schema in `backend/src/app.module.ts`, specifically: `PORT`, `CORS_ORIGIN`, `DATABASE_URL`, `JWT_SECRET`, `HORIZON_URL`, `STELLAR_NETWORK_PASSPHRASE`, `MERCHANT_PUBLIC_KEY`, `USDC_ISSUER`, `USDC_ASSET_CODE`, `MEMO_PREFIX`, `HORIZON_POLL_INTERVAL`, `SOROBAN_RPC_URL`, `SOROBAN_CONTRACT_ID`, `ADMIN_SECRET_KEY`, `SOROBAN_EVENT_TOPIC`, `THROTTLE_TTL`, `THROTTLE_LIMIT`, `THROTTLE_AUTH_TTL`, `THROTTLE_AUTH_LIMIT`, `THROTTLE_INVOICE_TTL`, `THROTTLE_INVOICE_LIMIT`, `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`, `REDIS_KEY_PREFIX`, `SLOW_DB_THRESHOLD_MS`, and `SLOW_NETWORK_THRESHOLD_MS`. Any variable present in the Joi schema but absent from the file SHALL cause this criterion to fail.
+2. WHEN a variable has a safe default value defined in the Joi schema or config factory, THE Backend `backend/.env.example` SHALL show that exact default as the placeholder value (e.g., `PORT=3001`, `REDIS_HOST=localhost`).
+3. WHEN a variable is required with no default — specifically `DATABASE_URL` and `JWT_SECRET` — THE Backend `backend/.env.example` SHALL include an inline comment on the same line or the line immediately above that describes what value to supply and, where applicable, how to generate it (e.g., `# generate with: openssl rand -base64 32` for `JWT_SECRET`).
+4. WHEN a variable is a secret — specifically `JWT_SECRET`, `ADMIN_SECRET_KEY`, and `REDIS_PASSWORD` — THE Backend `backend/.env.example` SHALL include a comment containing the exact text `WARNING: never commit a real value` on the line immediately above or inline with that variable.
+5. THE Backend `backend/.env.example` SHALL group variables under clearly labeled comment sections using the `# ── Section Name ──` format, with the following sections present in order: `Database`, `JWT`, `Stellar Network`, `Soroban Contract`, `Rate Limiting`, `Redis`, and `Observability`.
+6. Each variable in `backend/.env.example` SHALL be annotated with either `# required` or `# optional` as an inline or preceding comment, matching its `required()`/`optional()` designation in the Joi schema.
+
+---
+
+### Requirement 2: Web app env example file
+
+**User Story:** As a Contributor, I want a `.env.example` file in the web app directory, so that I can configure the Next.js frontend without guessing which `NEXT_PUBLIC_` variables are needed.
+
+#### Acceptance Criteria
+
+1. THE Web app SHALL have a `.env.example` file at `web/.env.example`, and this file SHALL be tracked by git (i.e., not matched by any `.gitignore` pattern in the repository).
+2. THE `web/.env.example` SHALL include `NEXT_PUBLIC_API_URL` with a placeholder value of `http://localhost:3001` and an inline comment of `# required`.
+3. THE `web/.env.example` SHALL include `NEXT_PUBLIC_USDC_ISSUER` with the value `GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN` and an inline comment reading `# Testnet default; replace with mainnet issuer for production`.
+4. THE `web/.env.example` SHALL contain an entry for every `process.env.*` variable read by web app source files (under `web/`) without a hardcoded fallback value. IF a `process.env` read is added to the web app source without a corresponding entry in `web/.env.example`, THEN the file SHALL be considered incomplete.
+5. THE `web/README.md` SHALL include a setup step that contains the exact copy command `cp web/.env.example web/.env.local` (or its OS equivalent) and instructs contributors to run it before executing `npm run dev`.
+
+---
+
+### Requirement 3: Mobile app env example file
+
+**User Story:** As a Contributor, I want a `.env.example` file in the mobile app directory, so that I can set up the Expo app without reading internal source files to discover which `@env` variables are required.
+
+#### Acceptance Criteria
+
+1. THE Mobile app SHALL have a `.env.example` file at `mobile/.env.example`, and this file SHALL be tracked by git (i.e., not matched by any `.gitignore` rule — note the root `.gitignore` uses `.env.*` which would match `.env.example`, so `.env.example` SHALL be explicitly unignored with a `!.env.example` rule or equivalent).
+2. THE `mobile/.env.example` SHALL include all variables declared in `mobile/types/env.d.ts`: `API_URL`, `STELLAR_NETWORK_PASSPHRASE`, `REOWN_PROJECT_ID`, and `APP_NAME`. If new variables are added to `env.d.ts`, they SHALL be added to `mobile/.env.example` in the same change.
+3. IF a variable has a safe testnet default, THEN THE `mobile/.env.example` SHALL show that default as the placeholder value: `API_URL=http://localhost:3001`, `STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"`, `APP_NAME=Invoisio`.
+4. IF a variable requires a contributor-specific value with no safe default — specifically `REOWN_PROJECT_ID` — THEN THE `mobile/.env.example` SHALL include an inline comment reading `# required — obtain from https://cloud.reown.com`.
+5. THE `mobile/SMOKE_TEST_CHECKLIST.md` SHALL include a setup step containing the exact copy command `cp mobile/.env.example mobile/.env` (or its OS equivalent) and the Expo dev server start command, before any smoke test steps that require the app to run.
+6. THE `mobile/.env.example` file SHALL NOT be matched by any `.gitignore` pattern at the repo root or within `mobile/`. A `!mobile/.env.example` negation rule (or equivalent) SHALL be added to the root `.gitignore` to ensure the file is committed.
+
+---
+
+### Requirement 4: Soroban client env example file
+
+**User Story:** As a Contributor, I want a `.env.example` file in the Soroban client directory, so that I can run the example scripts without manually reconstructing the required variables from the README prose.
+
+#### Acceptance Criteria
+
+1. THE Soroban_Client SHALL have a `.env.example` file at `soroban/client/.env.example`, tracked by git (not matched by any `.gitignore` pattern).
+2. THE `soroban/client/.env.example` SHALL include `SOROBAN_RPC_URL` with the value `https://soroban-testnet.stellar.org` and an inline comment of `# required`.
+3. THE `soroban/client/.env.example` SHALL include `STELLAR_NETWORK_PASSPHRASE` with the value `"Test SDF Network ; September 2015"` and an inline comment of `# required`.
+4. THE `soroban/client/.env.example` SHALL include `SOROBAN_CONTRACT_ID` with a placeholder (e.g., `CXXX...`) and a comment reading `# required — copy from soroban/contracts/invoice-payment/.contract-id after deployment`. This variable is read by the TypeScript client scripts (e.g., `soroban-config.ts`).
+5. THE `soroban/client/.env.example` SHALL include `CONTRACT_ID` with the same placeholder and a comment reading `# required — same value as SOROBAN_CONTRACT_ID; read by query-config.ts via process.env.CONTRACT_ID`. This addresses the fact that `query-config.ts` reads `process.env.CONTRACT_ID` rather than `SOROBAN_CONTRACT_ID`.
+6. THE `soroban/client/.env.example` SHALL include `ADMIN_SECRET_KEY` with the placeholder `SXXX...` and a comment containing the exact text `WARNING: never commit a real value` on the line immediately above or inline.
+7. THE `soroban/client/.env.example` SHALL include `SOURCE_PUBLIC_KEY` with the placeholder `GXXX...` and an inline comment reading `# optional — used for read-only operations; fallback when ADMIN_SECRET_KEY is absent`.
+8. THE `soroban/client/.env.example` SHALL include `PAYER_PUBLIC_KEY` with the placeholder `GXXX...` and an inline comment reading `# optional — payer address used in the example:record script; fallback to SOURCE_PUBLIC_KEY when absent`.
+9. THE `soroban/client/.env.example` SHALL include `INVOICE_ID` with the placeholder value `invoisio-demo-001` and an inline comment reading `# optional — overrides the default invoice ID in example scripts`.
+10. THE `soroban/README.md` "TypeScript Client Helper" setup subsection SHALL contain a `cp soroban/client/.env.example soroban/client/.env` step, and the file `soroban/client/.env.example` SHALL exist at that exact path so the command succeeds.
+
+---
+
+### Requirement 5: Consistent formatting and cross-app alignment
+
+**User Story:** As a Contributor, I want the env example files across all apps to follow a consistent structure, so that I can scan any file and immediately understand which variables are required, which are optional, and how they relate to shared Stellar configuration.
+
+#### Acceptance Criteria
+
+1. THE Env_Example_File for each of the four surfaces (`backend/.env.example`, `web/.env.example`, `mobile/.env.example`, `soroban/client/.env.example`) SHALL use `# ── Section Name ──` comment headers to group related variables, and each variable SHALL carry either a `# required` or `# optional` inline or preceding annotation.
+2. WHEN the same Stellar network variable appears in multiple Env_Example_Files — specifically `STELLAR_NETWORK_PASSPHRASE`, `SOROBAN_RPC_URL` (where applicable), and `USDC_ISSUER` / `NEXT_PUBLIC_USDC_ISSUER` — THE placeholder values SHALL be byte-for-byte identical across all files that include that variable.
+3. WHEN a variable is a secret — defined as: a private key (value starting with `S` for Stellar secret keys), a JWT secret, a database password, or a third-party API key — THE Env_Example_File SHALL include a comment containing the exact text `WARNING: never commit a real value` on the line immediately above or inline with that variable.
+4. THE root `README.md` SHALL include or link to an "Environment Setup" section that explicitly names all four surfaces and their example files: `backend/.env.example`, `web/.env.example`, `mobile/.env.example`, and `soroban/client/.env.example`, and directs contributors to the relevant per-app README or checklist for detailed setup instructions.
+5. IF a variable is referenced in an app's source code via `process.env.*`, a typed `@env` import, or a config factory without a hardcoded fallback value, AND that variable is absent from the app's Env_Example_File, THEN the Env_Example_File SHALL be considered incomplete and SHALL be updated to include it before the change is merged.
+6. Each of the four Env_Example_Files SHALL exist at its designated path as a committed, git-tracked file. The root `.gitignore` pattern `.env.*` currently matches `.env.example` files; therefore, a negation rule `!**/.env.example` (or per-path equivalents) SHALL be added to the root `.gitignore` so that all four example files are tracked by git.

--- a/.kiro/specs/env-setup-alignment/tasks.md
+++ b/.kiro/specs/env-setup-alignment/tasks.md
@@ -1,0 +1,427 @@
+# Implementation Tasks
+
+## Task List
+
+- [ ] 1. Fix root `.gitignore` so `.env.example` files are git-tracked
+- [ ] 2. Patch `backend/.env.example` to be complete and annotated
+- [ ] 3. Create `web/.env.example`
+- [ ] 4. Create `mobile/.env.example`
+- [ ] 5. Create `soroban/client/.env.example`
+- [ ] 6. Update `web/README.md` with environment setup step
+- [ ] 7. Update `mobile/SMOKE_TEST_CHECKLIST.md` with environment setup step
+- [ ] 8. Update `soroban/README.md` TypeScript Client Helper setup step
+- [ ] 9. Update root `README.md` with Environment Setup section
+
+---
+
+## Task Details
+
+### Task 1: Fix root `.gitignore` so `.env.example` files are git-tracked
+
+**Description:**  
+The root `.gitignore` contains `.env.*`, which glob-matches every `.env.example` file in the repo. Without a negation rule, all four `.env.example` files created by this feature will be silently ignored by git and never committed. Add `!**/.env.example` immediately after the `.env.*` line.
+
+**Files to change:**
+- `.gitignore`
+
+**Exact change:**  
+In the `# Environment files` block, after `.env.*`, add the negation line:
+
+```
+# Environment files
+.env
+.env.*
+!**/.env.example
+```
+
+**Verification:** After this change, running `git check-ignore -v backend/.env.example` should produce no output (file is not ignored).
+
+**Requirements addressed:** 2.1, 3.1, 3.6, 4.1, 5.6
+
+---
+
+### Task 2: Patch `backend/.env.example` to be complete and annotated
+
+**Description:**  
+The current `backend/.env.example` is missing the following variables that are present in the Joi schema: `PORT`, `CORS_ORIGIN`, `SOROBAN_EVENT_TOPIC`, all `THROTTLE_*` vars, all `REDIS_*` vars, and both `SLOW_*_THRESHOLD_MS` vars. It also lacks `# required` / `# optional` annotations and a `WARNING: never commit a real value` comment on `REDIS_PASSWORD`. Rewrite the file to cover all 27 Joi-validated variables, grouped under 8 section headers.
+
+**Files to change:**
+- `backend/.env.example`
+
+**Complete replacement content:**
+
+```dotenv
+# ── Database ─────────────────────────────────────────────────────────────────
+# required — set to your PostgreSQL connection string
+# e.g. postgresql://user:password@localhost:5432/invoisio_db
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/invoisio_db # required
+
+# ── JWT ──────────────────────────────────────────────────────────────────────
+# WARNING: never commit a real value
+# required — generate with: openssl rand -base64 32
+JWT_SECRET=change-me-generate-with-openssl-rand-base64-32 # required
+
+# ── App ──────────────────────────────────────────────────────────────────────
+PORT=3001                           # optional
+CORS_ORIGIN=http://localhost:3000   # optional
+
+# ── Stellar Network ──────────────────────────────────────────────────────────
+# Testnet: https://horizon-testnet.stellar.org
+# Mainnet: https://horizon.stellar.org
+HORIZON_URL=https://horizon-testnet.stellar.org                               # optional
+# Testnet: "Test SDF Network ; September 2015"
+# Mainnet: "Public Global Stellar Network ; September 2015"
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"                # optional
+MERCHANT_PUBLIC_KEY=                                                            # optional
+# Testnet default; replace with mainnet issuer for production
+USDC_ISSUER=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN        # optional
+USDC_ASSET_CODE=USDC                                                            # optional
+MEMO_PREFIX=invoisio-                                                           # optional
+HORIZON_POLL_INTERVAL=15000                                                     # optional
+
+# ── Soroban Contract ─────────────────────────────────────────────────────────
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org                             # optional
+# Copy from soroban/contracts/invoice-payment/.contract-id after deployment
+SOROBAN_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX # optional
+# WARNING: never commit a real value
+ADMIN_SECRET_KEY=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX    # optional
+SOROBAN_EVENT_TOPIC=InvoicePaymentRecorded                                      # optional
+
+# ── Rate Limiting ─────────────────────────────────────────────────────────────
+THROTTLE_TTL=60            # optional — general window in seconds
+THROTTLE_LIMIT=100         # optional — max requests per window
+THROTTLE_AUTH_TTL=900      # optional — auth endpoint window in seconds
+THROTTLE_AUTH_LIMIT=5      # optional — max auth requests per window
+THROTTLE_INVOICE_TTL=3600  # optional — invoice endpoint window in seconds
+THROTTLE_INVOICE_LIMIT=20  # optional — max invoice requests per window
+
+# ── Redis ─────────────────────────────────────────────────────────────────────
+REDIS_HOST=localhost         # optional
+REDIS_PORT=6379              # optional
+# WARNING: never commit a real value
+REDIS_PASSWORD=              # optional
+REDIS_DB=0                   # optional
+REDIS_KEY_PREFIX=invoisio:throttle: # optional
+
+# ── Observability ─────────────────────────────────────────────────────────────
+SLOW_DB_THRESHOLD_MS=200      # optional — log warning when DB query exceeds this ms
+SLOW_NETWORK_THRESHOLD_MS=500 # optional — log warning when network call exceeds this ms
+```
+
+**Requirements addressed:** 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 5.1, 5.2, 5.3
+
+---
+
+### Task 3: Create `web/.env.example`
+
+**Description:**  
+The web app has no `.env.example` at all. Static analysis found two `process.env.*` reads in the web source: `NEXT_PUBLIC_API_URL` (in `web/lib/api-client.ts`) and `NEXT_PUBLIC_USDC_ISSUER` (in `web/app/pos/page.tsx`). Both have runtime fallbacks, so they are optional, but must be documented.
+
+**Files to change:**
+- `web/.env.example` (new file)
+
+**Complete content:**
+
+```dotenv
+# ── API ───────────────────────────────────────────────────────────────────────
+# URL of the Invoisio backend API
+NEXT_PUBLIC_API_URL=http://localhost:3001 # optional
+
+# ── Stellar ───────────────────────────────────────────────────────────────────
+# Testnet default; replace with mainnet issuer for production
+NEXT_PUBLIC_USDC_ISSUER=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN # optional
+```
+
+**Requirements addressed:** 2.1, 2.2, 2.3, 2.4, 5.1, 5.2, 5.6
+
+---
+
+### Task 4: Create `mobile/.env.example`
+
+**Description:**  
+The mobile app has no `.env.example`. All required variables are declared in `mobile/types/env.d.ts`: `API_URL`, `STELLAR_NETWORK_PASSPHRASE`, `REOWN_PROJECT_ID`, and `APP_NAME`. `REOWN_PROJECT_ID` requires a contributor-specific value obtained from the Reown Cloud dashboard.
+
+**Files to change:**
+- `mobile/.env.example` (new file)
+
+**Complete content:**
+
+```dotenv
+# ── API ───────────────────────────────────────────────────────────────────────
+API_URL=http://localhost:3001 # optional
+
+# ── Stellar ───────────────────────────────────────────────────────────────────
+# Testnet: "Test SDF Network ; September 2015"
+# Mainnet: "Public Global Stellar Network ; September 2015"
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015" # optional
+
+# ── Wallet Connect ───────────────────────────────────────────────────────────
+# required — obtain from https://cloud.reown.com
+REOWN_PROJECT_ID=your-reown-project-id-here # required
+
+# ── App ──────────────────────────────────────────────────────────────────────
+APP_NAME=Invoisio # optional
+```
+
+**Requirements addressed:** 3.1, 3.2, 3.3, 3.4, 3.6, 5.1, 5.2, 5.6
+
+---
+
+### Task 5: Create `soroban/client/.env.example`
+
+**Description:**  
+The `soroban/README.md` TypeScript Client Helper section already instructs contributors to run `cp .env.example .env`, but the file does not exist. Static analysis of the example scripts revealed that `query-config.ts` reads `process.env.CONTRACT_ID` (not `SOROBAN_CONTRACT_ID`), so both variables must be documented.
+
+**Files to change:**
+- `soroban/client/.env.example` (new file)
+
+**Complete content:**
+
+```dotenv
+# ── Soroban Network ──────────────────────────────────────────────────────────
+# Testnet: https://soroban-testnet.stellar.org
+# Mainnet: https://soroban.stellar.org
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org # required
+# Testnet: "Test SDF Network ; September 2015"
+# Mainnet: "Public Global Stellar Network ; September 2015"
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015" # required
+
+# ── Contract ─────────────────────────────────────────────────────────────────
+# required — copy from soroban/contracts/invoice-payment/.contract-id after deployment
+SOROBAN_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX # required
+# required — same value as SOROBAN_CONTRACT_ID; read by query-config.ts via process.env.CONTRACT_ID
+CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX         # required
+
+# ── Keys ─────────────────────────────────────────────────────────────────────
+# WARNING: never commit a real value
+ADMIN_SECRET_KEY=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX    # optional — required for write operations (example:record)
+# optional — used for read-only operations; fallback when ADMIN_SECRET_KEY is absent
+SOURCE_PUBLIC_KEY=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX   # optional
+# optional — payer address used in the example:record script; fallback to SOURCE_PUBLIC_KEY when absent
+PAYER_PUBLIC_KEY=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX    # optional
+
+# ── Examples ─────────────────────────────────────────────────────────────────
+# optional — overrides the default invoice ID in example scripts
+INVOICE_ID=invoisio-demo-001 # optional
+```
+
+**Requirements addressed:** 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.1, 5.2, 5.3, 5.6
+
+---
+
+### Task 6: Update `web/README.md` with environment setup step
+
+**Description:**  
+The current `web/README.md` is the boilerplate Next.js README with no Invoisio-specific content. Replace it with a minimal but useful README that preserves the Getting Started section and adds an environment setup step before the dev server command.
+
+**Files to change:**
+- `web/README.md`
+
+**Complete replacement content:**
+
+```markdown
+# Invoisio — Web App
+
+The Next.js frontend for Invoisio, a privacy-first invoice platform on Stellar.
+
+## Getting Started
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Configure environment variables
+
+```bash
+cp web/.env.example web/.env.local
+```
+
+Edit `web/.env.local` and set the required values (see `web/.env.example` for documentation of each variable).
+
+### 3. Run the development server
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the app.
+
+The backend API must be running at the URL configured in `NEXT_PUBLIC_API_URL` (default: `http://localhost:3001`). See `backend/README.md` for backend setup.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEXT_PUBLIC_API_URL` | `http://localhost:3001` | URL of the Invoisio backend API |
+| `NEXT_PUBLIC_USDC_ISSUER` | Testnet issuer | USDC issuer address — use testnet default for development |
+
+Copy `web/.env.example` to `web/.env.local` for local development. Do **not** commit `.env.local`.
+
+## Learn More
+
+- [Next.js Documentation](https://nextjs.org/docs)
+- [Invoisio Backend README](../backend/README.md)
+- [Root README](../README.md)
+```
+
+**Requirements addressed:** 2.5
+
+---
+
+### Task 7: Update `mobile/SMOKE_TEST_CHECKLIST.md` with environment setup step
+
+**Description:**  
+The "Before you start" section of `mobile/SMOKE_TEST_CHECKLIST.md` currently jumps straight to `npm install` without any mention of environment configuration. A contributor would fail at step 4 (starting the app) because the required env vars would be missing. Insert the env setup step as step 2 (after `npm install`), shifting existing steps down.
+
+**Files to change:**
+- `mobile/SMOKE_TEST_CHECKLIST.md`
+
+**Change:** In the `## Before you start` section, replace:
+
+```markdown
+1. Install dependencies:
+   ```bash
+   cd mobile
+   npm install
+   ```
+2. Ensure the backend/API is running and reachable with the correct mobile configuration.
+```
+
+with:
+
+```markdown
+1. Install dependencies:
+   ```bash
+   cd mobile
+   npm install
+   ```
+2. Configure environment variables:
+   ```bash
+   cp mobile/.env.example mobile/.env
+   ```
+   Edit `mobile/.env` and set `REOWN_PROJECT_ID` to your project ID from [https://cloud.reown.com](https://cloud.reown.com). All other variables have safe defaults for local development.
+3. Ensure the backend/API is running and reachable with the correct mobile configuration.
+```
+
+Renumber the remaining steps (old 3 → new 4, old 4 → new 5).
+
+**Requirements addressed:** 3.5
+
+---
+
+### Task 8: Update `soroban/README.md` TypeScript Client Helper setup step
+
+**Description:**  
+The `soroban/README.md` TypeScript Client Helper "Setup" subsection already contains `cp .env.example .env` but references a relative path (`.env.example`) rather than the repo-relative path. Update it to `cp soroban/client/.env.example soroban/client/.env` and expand the configuration table to include the two variables discovered by static analysis (`CONTRACT_ID` and `PAYER_PUBLIC_KEY`) that are currently undocumented in the README prose.
+
+**Files to change:**
+- `soroban/README.md`
+
+**Change 1:** In the `### Setup` subsection, replace:
+
+```markdown
+# 2. Copy and configure environment variables
+cp .env.example .env
+# Edit .env — fill in SOROBAN_RPC_URL, SOROBAN_CONTRACT_ID, etc.
+```
+
+with:
+
+```markdown
+# 2. Copy and configure environment variables
+cp soroban/client/.env.example soroban/client/.env
+# Edit soroban/client/.env — fill in SOROBAN_RPC_URL, SOROBAN_CONTRACT_ID, etc.
+```
+
+**Change 2:** In the `### Configuration (.env)` table, replace the existing 5-row table:
+
+```markdown
+| Variable | Description |
+|----------|-------------|
+| `SOROBAN_RPC_URL` | Soroban RPC endpoint (testnet: `https://soroban-testnet.stellar.org`) |
+| `STELLAR_NETWORK_PASSPHRASE` | Network passphrase |
+| `SOROBAN_CONTRACT_ID` | Deployed contract ID from `.contract-id` |
+| `ADMIN_SECRET_KEY` | Admin secret key — write operations only; never commit |
+| `SOURCE_PUBLIC_KEY` | Any funded public key — read-only operations |
+```
+
+with the expanded 8-row table:
+
+```markdown
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SOROBAN_RPC_URL` | required | Soroban RPC endpoint (testnet: `https://soroban-testnet.stellar.org`) |
+| `STELLAR_NETWORK_PASSPHRASE` | required | Network passphrase |
+| `SOROBAN_CONTRACT_ID` | required | Deployed contract ID from `soroban/contracts/invoice-payment/.contract-id` |
+| `CONTRACT_ID` | required | Same value as `SOROBAN_CONTRACT_ID`; read by `query-config.ts` via `process.env.CONTRACT_ID` |
+| `ADMIN_SECRET_KEY` | write ops | Admin secret key — **never commit a real value** |
+| `SOURCE_PUBLIC_KEY` | read ops | Any funded public key — used for read-only operations |
+| `PAYER_PUBLIC_KEY` | optional | Payer address used in the `example:record` script |
+| `INVOICE_ID` | optional | Overrides the default invoice ID in example scripts (default: `invoisio-demo-001`) |
+```
+
+**Requirements addressed:** 4.10
+
+---
+
+### Task 9: Update root `README.md` with Environment Setup section
+
+**Description:**  
+The root `README.md` still references legacy directory names (`webapp/`, `smart-contracts/`) instead of the current names (`web/`, `soroban/`). It also has no unified "Environment Setup" section. Add a new `## 🔑 Environment Setup` section after the `## 🚀 Quick Start` section (which itself needs its directory references corrected), listing all four surfaces and their `.env.example` files.
+
+**Files to change:**
+- `README.md`
+
+**Change 1:** Update the Monorepo Structure code block, replacing outdated paths:
+
+Replace:
+```markdown
+```
+./
+├── webapp/         # Next.js 14 app (frontend UI)
+├── backend/        # New Stellar-first NestJS API (invoices, payments, Soroban integration)
+├── smart-contracts/ # Soroban smart contracts (Rust · stellar contract init)
+│   └── contracts/
+│       └── invoice-payment/   # Invoice payment tracking contract
+└── legacy/         # All legacy code kept during migration
+    ├── backend-legacy/ # Original backend kept as reference during migration
+    └── legacy-evm/     # EVM prototype (Solidity + Hardhat)
+        ├── contracts/  # Solidity PaymentRouter and related contracts
+        └── hardhat/    # Hardhat project (compile/deploy EVM router)
+```
+```
+
+with:
+```markdown
+```
+./
+├── web/            # Next.js frontend (browser merchants)
+├── mobile/         # Expo / React Native app (iOS & Android merchants)
+├── backend/        # NestJS API (invoices, payments, Stellar & Soroban integration)
+└── soroban/        # Soroban smart contracts (Rust) + TypeScript client helper
+    ├── contracts/
+    │   └── invoice-payment/   # Invoice payment tracking contract
+    └── client/                # TypeScript client library for Node.js integrations
+```
+```
+
+**Change 2:** After the `## 🚀 Quick Start` section heading and prerequisites block, insert a new section:
+
+```markdown
+## 🔑 Environment Setup
+
+Each app surface has a `.env.example` file documenting the minimum required variables. Copy it to a local env file before starting the app.
+
+| Surface | Example file | Copy command | Per-app docs |
+|---------|-------------|--------------|--------------|
+| Backend | `backend/.env.example` | `cp backend/.env.example backend/.env` | [backend/README.md](backend/README.md) |
+| Web | `web/.env.example` | `cp web/.env.example web/.env.local` | [web/README.md](web/README.md) |
+| Mobile | `mobile/.env.example` | `cp mobile/.env.example mobile/.env` | [mobile/SMOKE_TEST_CHECKLIST.md](mobile/SMOKE_TEST_CHECKLIST.md) |
+| Soroban client | `soroban/client/.env.example` | `cp soroban/client/.env.example soroban/client/.env` | [soroban/README.md](soroban/README.md) |
+
+> **Never commit a real secret.** The example files contain only placeholder values. Keep real credentials in your local `.env` / `.env.local` files, which are git-ignored.
+```
+
+**Requirements addressed:** 5.4


### PR DESCRIPTION
Here's a summary of the 9 tasks:

#	Task	Files changed
1	Fix root .gitignore — add !**/.env.example negation	.gitignore
2	Patch  .env.example — add 14 missing vars, sections, annotations, secret warnings	.env.example
3	Create .env.example — 2 NEXT_PUBLIC_* vars .env.example (new)
4	Create  .env.example  — 4 @env vars from env.d.ts .env.example (new)
5	Create  .env.example — 8 vars incl. both CONTRACT_ID and SOROBAN_CONTRACT_ID .env.example (new)
6	Update README.md — add env setup step with cp command README.md
7	Update SMOKE_TEST_CHECKLIST.md — insert env setup step before smoke tests SMOKE_TEST_CHECKLIST.md
8	Update README.md — fix cp path, expand config table with CONTRACT_ID/PAYER_PUBLIC_KEY README.md
9	Update root README.md — fix legacy dir names, add Environment Setup table	README.md
Two things worth flagging before implementation begins: the CONTRACT_ID / SOROBAN_CONTRACT_ID split (task 5/8) is a real bug — query-config.ts reads a different env var name than the rest of the examples. And the root .gitignore fix (task 1) must land first, otherwise none of the new .env.example files will actually be committed.