### PR TITLE
fix(web): improve invoice detail responsiveness on tablet and mobile

### DIFF
--- a/web/app/invoices/[id]/page.tsx
+++ b/web/app/invoices/[id]/page.tsx
@@ -271,7 +271,7 @@ function InvoiceDetailContent() {
         <div className="overflow-hidden rounded-lg bg-white shadow">
           <div className="px-6 py-8 sm:px-8">
             {/* Invoice Header */}
-            <div className="mb-8 flex items-start justify-between border-b border-gray-200 pb-6">
+            <div className="mb-8 flex flex-col items-start gap-3 border-b border-gray-200 pb-6 sm:flex-row sm:justify-between">
               <div>
                 <p className="text-sm text-gray-500">Invoice</p>
                 <h1 className="text-3xl font-bold text-gray-900">
@@ -405,7 +405,7 @@ function InvoiceDetailContent() {
             {/* Payment Instructions */}
             {isPending && (
               <div className="mb-8 rounded-md border border-blue-200 bg-blue-50 p-4">
-                <div className="mb-3 flex items-center justify-between">
+                <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
                   <p className="text-xs font-medium uppercase text-blue-900">Payment Instructions</p>
                   <span className="text-xs text-slate-500">Copy destination and memo to pay</span>
                 </div>
@@ -453,7 +453,7 @@ function InvoiceDetailContent() {
 
             {/* Status Timeline */}
             <div className="mb-8 rounded-lg border border-slate-200 bg-slate-50 p-5">
-              <div className="mb-4 flex items-center justify-between gap-4">
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
                 <p className="text-xs font-medium uppercase tracking-wide text-slate-700">Status Timeline</p>
                 <span className="text-xs text-slate-500">
                   {lastUpdated ? `Last refreshed ${formatDateTime(lastUpdated)}` : 'No status timestamp available'}
@@ -488,7 +488,7 @@ function InvoiceDetailContent() {
             )}
 
             {/* Action Buttons */}
-            <div className="flex flex-col gap-3 sm:flex-row">
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
               {isPending && walletInfo?.hasWallet && (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
Part of the responsive layout audit from #224. I checked the dashboard, POS, invoice list, and invoice detail screens. The dashboard, POS, and invoice list already adapt well to tablet and mobile widths, so this PR focuses on the one screen with real gaps: the invoice detail page.

## Changes (web/app/invoices/[id]/page.tsx)
- Invoice header now stacks the invoice number and status badge vertically on narrow screens, and sits side-by-side from the `sm` breakpoint up.
- Payment Instructions heading row wraps instead of overflowing on small widths.
- Status Timeline heading row wraps instead of overflowing on small widths.
- Action buttons can wrap at tablet widths so they no longer run off the edge.

## Notes
- These are Tailwind class changes only — no logic or data flow was touched.
- Recommend a quick visual check at ~375px (mobile) and ~768px (tablet).

Closes #224